### PR TITLE
Support to get object IDs from deploymentScript or user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 1. Build the project by replacing all placeholder `${<place_holder>}` with valid values
    1. Create a new ARO 4 cluster:
       ```bash
-      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DidentityId=<user-assigned-managed-identity-id> -DcreateCluster=true -DaadClientId=<aad-client-id> -DaadClientSecret=<aad-client-secret> -DaadObjectId=<aad-object-id> -DrpObjectId=<aro-rp-object-id> -DprojMgrUsername=<project-mgr-username> -DprojMgrPassword=<project-mgr-username> -DuploadAppPackage=<true|false> -DuseOpenLibertyImage=<true|false> -DuseJava8=<true|false> -DcontextRoot=<context-root>  -DappReplicas=<app-replicas> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
+      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DidentityId=<user-assigned-managed-identity-id> -DcreateCluster=true -DaadClientId=<aad-client-id> -DaadClientSecret=<aad-client-secret> -Drequire.objectId=<true|false> -DprojMgrUsername=<project-mgr-username> -DprojMgrPassword=<project-mgr-username> -DuploadAppPackage=<true|false> -DuseOpenLibertyImage=<true|false> -DuseJava8=<true|false> -DcontextRoot=<context-root>  -DappReplicas=<app-replicas> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
       ```
 
    1. Use an existing ARO 4 cluster:
@@ -37,7 +37,7 @@
 1. Using `deploy.azcli` to deploy
 
    ```bash
-   ./deploy.azcli -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l eastus -f <app-package-path> -p <pull-secret-path>
+   ./deploy.azcli -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l eastus -f <app-package-path> -p <pull-secret-path> -a <aadObjectId> -r <rpObjectId>
    ```
 
 ## After deployment

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.13</version>
+    <version>1.0.14</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,5 +42,6 @@
         <customer.usage.attribution.id>pid-8942a2f7-32d6-4b69-b504-4c2fb23fe059-partnercenter</customer.usage.attribution.id>
         <aro.start>acdd32ed-5fab-54b6-8d5a-097ed3dcfcf2</aro.start>
         <aro.end>d9293179-8975-5587-b29f-8f09f2832c4f</aro.end>
+        <require.objectId>false</require.objectId>
     </properties>
 </project>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -7,10 +7,10 @@
             {
                 "name": "errInfo",
                 "type": "Microsoft.Common.InfoBox",
-                "visible": "[less(length(basics('identity').userAssignedIdentities),1)]",
+                "visible": "[less(length(basics('identity').userAssignedIdentities), 1)]",
                 "options": {
                     "icon": "Error",
-                    "text": "Select one user-assigned managed identity that has a contributor role in the subscription.<br><br>You can find more details from the following articles:<li><a href='https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity' target='_blank'>Create a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity' target='_blank'>Assign a role to a user-assigned managed identity</a></li>"
+                    "text": "[concat('Select one user-assigned managed identity that has a <b>Contributor</b> role in the subscription', if(bool(${require.objectId}), '', ' and an <b>Application administrator</b> role in Azure AD'), '.<br><br>You can find more details from the following articles:<li><a href=\\'https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity\\' target=\\'_blank\\'>Create a user-assigned managed identity</a></li><li><a href=\\'https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity\\' target=\\'_blank\\'>Assign a role to a user-assigned managed identity</a></li>', if(bool(${require.objectId}), '', '<li><a href=\\'https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role\\' target=\\'_blank\\'>Assign Azure AD roles to a user-assigned managed identity</a></li>'))]"
                 }
             },
             {
@@ -18,7 +18,7 @@
                 "type": "Microsoft.ManagedIdentity.IdentitySelector",
                 "label": "Managed Identity Configuration",
                 "toolTip": {
-                    "userAssignedIdentity": "Add a user-assigned managed identity that has a contributor role in the subscription to enable the application deployment."
+                    "userAssignedIdentity": "[concat('Add a user-assigned managed identity that has a <b>Contributor</b> role in the subscription', if(bool(${require.objectId}), '', ' and an <b>Application administrator</b> role in Azure AD'), ' to enable the application deployment.')]"
                 },
                 "defaultValue": {
                     "systemAssignedIdentity": "Off"
@@ -102,6 +102,30 @@
                                     "regex": "^.{8,}$",
                                     "validationMessage": "A valid client secret is required."
                                 }
+                            },
+                            {
+                                "name": "aadObjectId",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Object ID",
+                                "toolTip": "The object ID of the service principal for the Azure AD client application.<br><br>To get the service principal object ID value:<ol><li>In the <a href='https://portal.azure.com/' target='_blank'>Azure portal</a>, search for and select <b>Enterprise applications</b>.</li><li>In <b>Application type</b>, select <b>All applications</b>.</li><li>In the application search box, paste the <b>Application (client) ID</b> value. After the app registration appears in the search results table, select and copy the corresponding value in the <b>Object ID</b> column.</li></ol>",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}$",
+                                    "validationMessage": "The object ID must be a valid global unique identifier (GUID). Example: 00000000-0000-0000-0000-000000000000"
+                                },
+                                "visible": "[bool(${require.objectId})]"
+                            },
+                            {
+                                "name": "rpObjectId",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Object ID of Azure Red Hat OpenShift Resource Provider",
+                                "toolTip": "The object ID of the service principal for the Azure Red Hat OpenShift Resource Provider.<br><br>To get the service principal object ID value:<ol><li>In the <a href='https://portal.azure.com/' target='_blank'>Azure portal</a>, search for and select <b>Enterprise applications</b>.</li><li>In <b>Application type</b>, select <b>All applications</b>.</li><li>In the application search box, paste <b>Azure Red Hat OpenShift RP</b>. After the app registration appears in the search results table, select and copy the corresponding value in the <b>Object ID</b> column.</li></ol>",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}$",
+                                    "validationMessage": "The object ID must be a valid global unique identifier (GUID). Example: 00000000-0000-0000-0000-000000000000"
+                                },
+                                "visible": "[bool(${require.objectId})]"
                             }
                         ],
                         "visible": "[bool(steps('Cluster').createCluster)]"
@@ -302,6 +326,8 @@
             "pullSecret": "[steps('Cluster').createClusterInfo.pullSecret]",
             "aadClientId": "[steps('Cluster').createClusterInfo.aadClientId]",
             "aadClientSecret": "[steps('Cluster').createClusterInfo.aadClientSecret]",
+            "aadObjectId": "[steps('Cluster').createClusterInfo.aadObjectId]",
+            "rpObjectId": "[steps('Cluster').createClusterInfo.rpObjectId]",
             "clusterName": "[last(split(steps('Cluster').clusterInfo.clusterSelector.id, '/'))]",
             "clusterRGName": "[last(take(split(steps('Cluster').clusterInfo.clusterSelector.id, '/'), 5))]",
             "projMgrUsername": "[steps('Cluster').projectMgrInfo.projMgrUsername]",

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -102,28 +102,6 @@
                                     "regex": "^.{8,}$",
                                     "validationMessage": "A valid client secret is required."
                                 }
-                            },
-                            {
-                                "name": "aadObjectId",
-                                "type": "Microsoft.Common.TextBox",
-                                "label": "Object ID",
-                                "toolTip": "The object ID of the service principal for the Azure AD client application.<br><br>To get the service principal object ID value:<ol><li>In the <a href='https://portal.azure.com/' target='_blank'>Azure portal</a>, search for and select <b>Enterprise applications</b>.</li><li>In <b>Application type</b>, select <b>All applications</b>.</li><li>In the application search box, paste the <b>Application (client) ID</b> value. After the app registration appears in the search results table, select and copy the corresponding value in the <b>Object ID</b> column.</li></ol>",
-                                "constraints": {
-                                    "required": true,
-                                    "regex": "^[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}$",
-                                    "validationMessage": "The object ID must be a valid global unique identifier (GUID). Example: 00000000-0000-0000-0000-000000000000"
-                                }
-                            },
-                            {
-                                "name": "rpObjectId",
-                                "type": "Microsoft.Common.TextBox",
-                                "label": "Object ID of Azure Red Hat OpenShift Resource Provider",
-                                "toolTip": "The object ID of the service principal for the Azure Red Hat OpenShift Resource Provider.<br><br>To get the service principal object ID value:<ol><li>In the <a href='https://portal.azure.com/' target='_blank'>Azure portal</a>, search for and select <b>Enterprise applications</b>.</li><li>In <b>Application type</b>, select <b>All applications</b>.</li><li>In the application search box, paste <b>Azure Red Hat OpenShift RP</b>. After the app registration appears in the search results table, select and copy the corresponding value in the <b>Object ID</b> column.</li></ol>",
-                                "constraints": {
-                                    "required": true,
-                                    "regex": "^[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}$",
-                                    "validationMessage": "The object ID must be a valid global unique identifier (GUID). Example: 00000000-0000-0000-0000-000000000000"
-                                }
                             }
                         ],
                         "visible": "[bool(steps('Cluster').createCluster)]"
@@ -324,8 +302,6 @@
             "pullSecret": "[steps('Cluster').createClusterInfo.pullSecret]",
             "aadClientId": "[steps('Cluster').createClusterInfo.aadClientId]",
             "aadClientSecret": "[steps('Cluster').createClusterInfo.aadClientSecret]",
-            "aadObjectId": "[steps('Cluster').createClusterInfo.aadObjectId]",
-            "rpObjectId": "[steps('Cluster').createClusterInfo.rpObjectId]",
             "clusterName": "[last(split(steps('Cluster').clusterInfo.clusterSelector.id, '/'))]",
             "clusterRGName": "[last(take(split(steps('Cluster').clusterInfo.clusterSelector.id, '/'), 5))]",
             "projMgrUsername": "[steps('Cluster').projectMgrInfo.projMgrUsername]",

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -83,6 +83,20 @@
                 "description": "The secret of an Azure Active Directory client application"
             }
         },
+        "aadObjectId": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The Object ID of an Azure Active Directory client application"
+            }
+        },
+        "rpObjectId": {
+            "type": "String",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The Object ID of the Resource Provider Service Principal"
+            }
+        },
         "masterVmSize": {
             "type": "string",
             "defaultValue": "Standard_D8s_v3",
@@ -193,7 +207,7 @@
             }
         },
         {
-            "condition": "[parameters('createCluster')]",
+            "condition": "[and(parameters('createCluster'), empty(parameters('aadObjectId')), empty(parameters('rpObjectId')))]",
             "type": "Microsoft.Resources/deploymentScripts",
             "apiVersion": "${azure.apiVersion.deploymentScript}",
             "name": "[variables('name_getObjectIdDeploymentScriptName')]",
@@ -260,7 +274,7 @@
             ],
             "properties": {
                 "roleDefinitionId": "[variables('const_contribRole')]",
-                "principalId": "[reference(variables('name_getObjectIdDeploymentScriptName')).outputs.appSpObjectId]"
+                "principalId": "[if(and(parameters('createCluster'), empty(parameters('aadObjectId'))), reference(variables('name_getObjectIdDeploymentScriptName')).outputs.appSpObjectId, parameters('aadObjectId'))]"
             }
         },
         {
@@ -273,7 +287,7 @@
             ],
             "properties": {
                 "roleDefinitionId": "[variables('const_contribRole')]",
-                "principalId": "[reference(variables('name_getObjectIdDeploymentScriptName')).outputs.aroRpSpObjectId]"
+                "principalId": "[if(and(parameters('createCluster'), empty(parameters('rpObjectId'))), reference(variables('name_getObjectIdDeploymentScriptName')).outputs.aroRpSpObjectId, parameters('rpObjectId'))]"
             }
         },
         {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -83,20 +83,6 @@
                 "description": "The secret of an Azure Active Directory client application"
             }
         },
-        "aadObjectId": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The Object ID of an Azure Active Directory client application"
-            }
-        },
-        "rpObjectId": {
-            "type": "String",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The Object ID of the Resource Provider Service Principal"
-            }
-        },
         "masterVmSize": {
             "type": "string",
             "defaultValue": "Standard_D8s_v3",
@@ -174,7 +160,8 @@
         "const_suffix": "[take(replace(parameters('guidValue'), '-', ''), 6)]",
         "name_clusterName": "[if(parameters('createCluster'), concat('cluster', variables('const_suffix')), parameters('clusterName'))]",
         "name_clusterVNetName": "[concat('vnet', variables('const_suffix'))]",
-        "name_deploymentScriptName": "[concat('script', variables('const_suffix'))]"
+        "name_deploymentScriptName": "[concat('script', variables('const_suffix'))]",
+        "name_getObjectIdDeploymentScriptName": "[concat('getObjectIdScript', variables('const_suffix'))]"
     },
     "resources": [
         {
@@ -206,11 +193,30 @@
             }
         },
         {
+            "condition": "[parameters('createCluster')]",
+            "type": "Microsoft.Resources/deploymentScripts",
+            "apiVersion": "${azure.apiVersion.deploymentScript}",
+            "name": "[variables('name_getObjectIdDeploymentScriptName')]",
+            "location": "[parameters('location')]",
+            "kind": "AzureCLI",
+            "identity": "[parameters('identity')]",
+            "properties": {
+                "AzCliVersion": "2.15.0",
+                "arguments": "[parameters('aadClientId')]",
+                "primaryScriptUri": "[uri(variables('const_scriptLocation'), concat('get-object-id.sh', parameters('_artifactsLocationSasToken')))]",
+                "cleanupPreference": "OnSuccess",
+                "retentionInterval": "P1D"
+            }
+        },
+        {
            "condition": "[parameters('createCluster')]",
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "${azure.apiVersion}",
             "name": "[variables('name_clusterVNetName')]",
             "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deploymentScripts', variables('name_getObjectIdDeploymentScriptName'))]"
+            ],
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -248,26 +254,26 @@
             "condition": "[parameters('createCluster')]",
             "type": "Microsoft.Network/virtualNetworks/providers/roleAssignments",
             "apiVersion": "${azure.apiVersion.vNetRoleAssignment}",
-            "name": "[concat(variables('name_clusterVNetName'), '/Microsoft.Authorization/', guid(resourceGroup().id, deployment().name, 'aadObjectId', parameters('aadObjectId')))]",
+            "name": "[concat(variables('name_clusterVNetName'), '/Microsoft.Authorization/', guid(resourceGroup().id, deployment().name, 'aadObjectId'))]",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks', variables('name_clusterVNetName'))]"
             ],
             "properties": {
                 "roleDefinitionId": "[variables('const_contribRole')]",
-                "principalId": "[parameters('aadObjectId')]"
+                "principalId": "[reference(variables('name_getObjectIdDeploymentScriptName')).outputs.appSpObjectId]"
             }
         },
         {
             "condition": "[parameters('createCluster')]",
             "type": "Microsoft.Network/virtualNetworks/providers/roleAssignments",
             "apiVersion": "${azure.apiVersion.vNetRoleAssignment}",
-            "name": "[concat(variables('name_clusterVNetName'), '/Microsoft.Authorization/', guid(resourceGroup().id, deployment().name, 'rpObjectId', parameters('rpObjectId')))]",
+            "name": "[concat(variables('name_clusterVNetName'), '/Microsoft.Authorization/', guid(resourceGroup().id, deployment().name, 'rpObjectId'))]",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks', variables('name_clusterVNetName'))]"
             ],
             "properties": {
                 "roleDefinitionId": "[variables('const_contribRole')]",
-                "principalId": "[parameters('rpObjectId')]"
+                "principalId": "[reference(variables('name_getObjectIdDeploymentScriptName')).outputs.aroRpSpObjectId]"
             }
         },
         {

--- a/src/main/arm/parameters.json
+++ b/src/main/arm/parameters.json
@@ -34,12 +34,6 @@
         "aadClientSecret": {
             "value": "${aadClientSecret}"
         },
-        "aadObjectId": {
-            "value": "${aadObjectId}"
-        },
-        "rpObjectId": {
-            "value": "${rpObjectId}"
-        },
         "uploadAppPackage": {
             "value": "${uploadAppPackage}"
         },

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -21,17 +21,19 @@ IFS=$'\n\t'
 # -o: prevents errors in a pipeline from being masked
 # IFS new value is less likely to cause confusing bugs when looping arrays or arguments (e.g. $@)
 
-usage() { echo "Usage: $0 -n <deploymentName> -f <appPackage> -p <pullSecretFile> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
+usage() { echo "Usage: $0 -n <deploymentName> -f <appPackage> -p <pullSecretFile> -a <aadObjectId> -r <rpObjectId> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
 
 declare deploymentName=""
 declare appPackage=""
 declare pullSecretFile=""
+declare aadObjectId=""
+declare rpObjectId=""
 declare subscriptionId=""
 declare resourceGroupName=""
 declare resourceGroupLocation=""
 
 # Initialize parameters specified from command line
-while getopts ":n:f:p:i:g:l:" arg; do
+while getopts ":n:f:p:i:g:l:a:r:" arg; do
 	case "${arg}" in
 		n)
 			deploymentName=${OPTARG}
@@ -41,6 +43,12 @@ while getopts ":n:f:p:i:g:l:" arg; do
 			;;
 		p)
 			pullSecretFile=${OPTARG}
+			;;
+		a)
+			aadObjectId=${OPTARG}
+			;;
+		r)
+			rpObjectId=${OPTARG}
 			;;
 		i)
 			subscriptionId=${OPTARG}
@@ -233,6 +241,8 @@ appReplicas=$( echo $parametersJson | jq '.appReplicas.value' | sed 's/"//g' )
 parametersJson=$( echo $parametersJson | jq --argjson replicas "$appReplicas" '.appReplicas.value = $replicas' )
 parametersJson=$( echo "$parametersJson" | jq --arg uri "$appPackageUrl" '{"appPackageUrl": {"value":$uri}} + .' )
 parametersJson=$( echo "$parametersJson" | jq --arg pullSecret "$pullSecret" '{"pullSecret": {"value":$pullSecret}} + .' )
+parametersJson=$( echo "$parametersJson" | jq --arg aadObjectId "$aadObjectId" '{"aadObjectId": {"value":$aadObjectId}} + .' )
+parametersJson=$( echo "$parametersJson" | jq --arg rpObjectId "$rpObjectId" '{"rpObjectId": {"value":$rpObjectId}} + .' )
 parametersJson=$( echo "$parametersJson" | jq -c '.' )
 
 # Start deployment

--- a/src/main/scripts/get-object-id.sh
+++ b/src/main/scripts/get-object-id.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+appClientId=$1
+
+# Get object IDs
+appSpObjectId=$(az ad sp show --id ${appClientId} --query 'objectId' -o tsv)
+aroRpSpObjectId=$(az ad sp list --display-name "Azure Red Hat OpenShift RP" --query '[0].objectId' -o tsv)
+
+# Write outputs to deployment script output path
+result=$(jq -n -c --arg appSpObjectId $appSpObjectId '{appSpObjectId: $appSpObjectId}')
+result=$(echo "$result" | jq --arg aroRpSpObjectId "$aroRpSpObjectId" '{"aroRpSpObjectId": $aroRpSpObjectId} + .')
+echo $result > $AZ_SCRIPTS_OUTPUT_PATH

--- a/src/main/scripts/get-object-id.sh
+++ b/src/main/scripts/get-object-id.sh
@@ -18,7 +18,15 @@ appClientId=$1
 
 # Get object IDs
 appSpObjectId=$(az ad sp show --id ${appClientId} --query 'objectId' -o tsv)
+if [[ $? != 0 ]]; then
+  echo "Failed to get objectId for ${appClientId}."
+  exit 1
+fi
 aroRpSpObjectId=$(az ad sp list --display-name "Azure Red Hat OpenShift RP" --query '[0].objectId' -o tsv)
+if [[ $? != 0 ]]; then
+  echo "Failed to get objectId for \"Azure Red Hat OpenShift RP\"."
+  exit 1
+fi
 
 # Write outputs to deployment script output path
 result=$(jq -n -c --arg appSpObjectId $appSpObjectId '{appSpObjectId: $appSpObjectId}')


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #12 

## Change summary

* use deployment script to get object ids
* get object IDs from user input or deploymentScript

## Testing

The following test cases have already been passed before opening the PR:

* Failed to get object IDs with deploymentScript if the user-assigned managed identity doesn't have an application administrator role in Azure AD;
* Successfully deployed a Java app on an ARO cluster with object IDs retrieved by deploymentScript if the user-assigned managed identity has an application administrator role in Azure AD;
* Successfully deployed a Java app on an ARO cluster with user input object IDs;

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>