### PR TITLE
Improve stability of azure.liberty.aro offer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -394,6 +394,10 @@
             "value": "[reference(variables('name_deploymentScriptName')).outputs.consoleUrl]",
             "type": "string"
         },
+        "containerRegistryUrl": {
+            "value": "[reference(variables('name_deploymentScriptName')).outputs.containerRegistryUrl]",
+            "type": "string"
+        },
         "appName": {
             "value": "[variables('const_appName')]",
             "type": "string"

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -14,6 +14,37 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+wait_subscription_created() {
+    subscriptionName=$1
+    namespaceName=$2
+    logFile=$3
+
+    oc get packagemanifests -n openshift-marketplace | grep -q ${subscriptionName}
+    while [ $? -ne 0 ]
+    do
+        echo "Wait until the Operator ${subscriptionName} available to the cluster from OperatorHub..." >> $logFile
+        sleep 5
+        oc get packagemanifests -n openshift-marketplace | grep -q ${subscriptionName}
+    done
+
+    oc apply -f open-liberty-operator-subscription.yaml >> $logFile
+    while [ $? -ne 0 ]
+    do
+        echo "Failed to create subscription ${subscriptionName}, retry..." >> $logFile
+        sleep 5
+        oc apply -f open-liberty-operator-subscription.yaml >> $logFile
+    done
+
+    oc get subscription ${subscriptionName} -n ${namespaceName}
+    while [ $? -ne 0 ]
+    do
+        echo "Wait until the subscription ${subscriptionName} created..." >> $logFile
+        sleep 5
+        oc get subscription ${subscriptionName} -n ${namespaceName}
+    done
+    echo "Subscription ${subscriptionName} created." >> $logFile
+}
+
 wait_deployment_complete() {
     deploymentName=$1
     namespaceName=$2
@@ -81,7 +112,7 @@ consoleUrl=$(az aro show -g $clusterRGName -n $clusterName --query 'consoleProfi
 oc login -u $kubeadminUsername -p $kubeadminPassword --server="$apiServerUrl" >> $logFile
 
 # Install Open Liberty Operator V0.7.0
-oc apply -f open-liberty-operator-subscription.yaml >> $logFile
+wait_subscription_created open-liberty-certified openshift-operators ${logFile}
 wait_deployment_complete open-liberty-operator openshift-operators ${logFile}
 
 # Configure an HTPasswd identity provider
@@ -214,6 +245,7 @@ appEndpoint=$(echo ${appEndpoint}${Context_Root})
 
 # Write outputs to deployment script output path
 result=$(jq -n -c --arg consoleUrl $consoleUrl '{consoleUrl: $consoleUrl}')
+result=$(echo "$result" | jq --arg containerRegistryUrl "$registryHost" '{"containerRegistryUrl": $containerRegistryUrl} + .')
 if [ "$uploadAppPackage" = True ]; then
     result=$(echo "$result" | jq --arg appServerXml "$appServerXml" '{"appServerXml": $appServerXml} + .')
     result=$(echo "$result" | jq --arg appDockerfile "$appDockerfile" '{"appDockerfile": $appDockerfile} + .')

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -22,7 +22,7 @@ wait_subscription_created() {
     oc get packagemanifests -n openshift-marketplace | grep -q ${subscriptionName}
     while [ $? -ne 0 ]
     do
-        echo "Wait until the Operator ${subscriptionName} available to the cluster from OperatorHub..." >> $logFile
+        echo "Wait until the Operator ${subscriptionName} is available to the cluster from OperatorHub..." >> $logFile
         sleep 5
         oc get packagemanifests -n openshift-marketplace | grep -q ${subscriptionName}
     done
@@ -38,7 +38,7 @@ wait_subscription_created() {
     oc get subscription ${subscriptionName} -n ${namespaceName}
     while [ $? -ne 0 ]
     do
-        echo "Wait until the subscription ${subscriptionName} created..." >> $logFile
+        echo "Wait until the subscription ${subscriptionName} is created..." >> $logFile
         sleep 5
         oc get subscription ${subscriptionName} -n ${namespaceName}
     done


### PR DESCRIPTION
## Description

Reza tested the [preview link](https://portal.azure.com/#create/ibm-usa-ny-armonk-hq-6275750-ibmcloud-aiops.20210823-liberty-aro-previewliberty-aro) today and I found an issue which is not observed before: The open-liberty-operator deployment seems hang. The root cause seems the subscription `open-liberty-certified` is not created which caused the `open-liberty-operator` is not deployed either.  

## Change summary

* Wait until subscription open-liberty-certified created
* Expose `containerRegistryUrl` in outputs of deployment

## Testing

Tested using Azure CLI command and [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro) of testing offer, the issue is not reproduced.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>