### PR TITLE
Enhancement of liberty on aro offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 1. Build the project by replacing all placeholder `${<place_holder>}` with valid values
    1. Create a new ARO 4 cluster:
       ```bash
-      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DidentityId=<user-assigned-managed-identity-id> -DcreateCluster=true -DaadClientId=<aad-client-id> -DaadClientSecret=<aad-client-secret> -Drequire.objectId=<true|false> -DprojMgrUsername=<project-mgr-username> -DprojMgrPassword=<project-mgr-username> -DuploadAppPackage=<true|false> -DuseOpenLibertyImage=<true|false> -DuseJava8=<true|false> -DcontextRoot=<context-root>  -DappReplicas=<app-replicas> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
+      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DidentityId=<user-assigned-managed-identity-id> -DcreateCluster=true -DuamiHasAppAdminRole=<true|false> -DprojMgrUsername=<project-mgr-username> -DprojMgrPassword=<project-mgr-username> -DuploadAppPackage=<true|false> -DuseOpenLibertyImage=<true|false> -DuseJava8=<true|false> -DcontextRoot=<context-root>  -DappReplicas=<app-replicas> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
       ```
 
    1. Use an existing ARO 4 cluster:
@@ -37,7 +37,7 @@
 1. Using `deploy.azcli` to deploy
 
    ```bash
-   ./deploy.azcli -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l eastus -f <app-package-path> -p <pull-secret-path> -a <aadObjectId> -r <rpObjectId>
+   ./deploy.azcli -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l eastus -f <app-package-path> -p <pull-secret-path> -c <aadClientId> -s <aadClientSecret> -a <aadObjectId> -r <rpObjectId>
    ```
 
 ## After deployment

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
@@ -42,6 +42,6 @@
         <customer.usage.attribution.id>pid-8942a2f7-32d6-4b69-b504-4c2fb23fe059-partnercenter</customer.usage.attribution.id>
         <aro.start>acdd32ed-5fab-54b6-8d5a-097ed3dcfcf2</aro.start>
         <aro.end>d9293179-8975-5587-b29f-8f09f2832c4f</aro.end>
-        <require.objectId>false</require.objectId>
+        <uamiHasAppAdminRole>true</uamiHasAppAdminRole>
     </properties>
 </project>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -10,7 +10,7 @@
                 "visible": "[less(length(basics('identity').userAssignedIdentities), 1)]",
                 "options": {
                     "icon": "Error",
-                    "text": "[concat('Select one user-assigned managed identity that has a <b>Contributor</b> role in the subscription', if(bool(${require.objectId}), '', ' and an <b>Application administrator</b> role in Azure AD'), '.<br><br>You can find more details from the following articles:<li><a href=\\'https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity\\' target=\\'_blank\\'>Create a user-assigned managed identity</a></li><li><a href=\\'https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity\\' target=\\'_blank\\'>Assign a role to a user-assigned managed identity</a></li>', if(bool(${require.objectId}), '', '<li><a href=\\'https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role\\' target=\\'_blank\\'>Assign Azure AD roles to a user-assigned managed identity</a></li>'))]"
+                    "text": "[concat('Select one user-assigned managed identity that has a <b>Contributor</b> role in the subscription', if(bool(${uamiHasAppAdminRole}), ' and an <b>Application administrator</b> role in Azure AD', ''), '.<br><br>You can find more details from the following articles:<li><a href=\\'https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity\\' target=\\'_blank\\'>Create a user-assigned managed identity</a></li><li><a href=\\'https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity\\' target=\\'_blank\\'>Assign a role to a user-assigned managed identity</a></li>', if(bool(${uamiHasAppAdminRole}), '<li><a href=\\'https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role\\' target=\\'_blank\\'>Assign Azure AD roles to a user-assigned managed identity</a></li>', ''))]"
                 }
             },
             {
@@ -18,7 +18,7 @@
                 "type": "Microsoft.ManagedIdentity.IdentitySelector",
                 "label": "Managed Identity Configuration",
                 "toolTip": {
-                    "userAssignedIdentity": "[concat('Add a user-assigned managed identity that has a <b>Contributor</b> role in the subscription', if(bool(${require.objectId}), '', ' and an <b>Application administrator</b> role in Azure AD'), ' to enable the application deployment.')]"
+                    "userAssignedIdentity": "[concat('Add a user-assigned managed identity that has a <b>Contributor</b> role in the subscription', if(bool(${uamiHasAppAdminRole}), ' and an <b>Application administrator</b> role in Azure AD', ''), ' to enable the application deployment.')]"
                 },
                 "defaultValue": {
                     "systemAssignedIdentity": "Off"
@@ -43,7 +43,7 @@
                                 "label": "Issue tracker",
                                 "uri": "https://aka.ms/azure-liberty-aro-issues?version=${project.version}"
                             }
-                        }   
+                        }
                     },
                     {
                         "name": "howToReportVendorIssueText",
@@ -55,7 +55,7 @@
                                 "label": "IBM support",
                                 "uri": "https://www.ibm.com/mysupport/"
                             }
-                        }   
+                        }
                     },
                     {
                         "name": "howToCommunityHelp",
@@ -92,10 +92,10 @@
                                 "uri": "https://aka.ms/ibm-stack-migration-survey"
                             }
                         }
-                    }                    
+                    }
                 ],
                 "visible": true
-            }            
+            }
         ],
         "steps": [
             {
@@ -155,7 +155,8 @@
                                     "required": true,
                                     "regex": "^[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}$",
                                     "validationMessage": "The application (client) ID must be a valid global unique identifier (GUID). Example: 00000000-0000-0000-0000-000000000000"
-                                }
+                                },
+                                "visible": "[not(bool(${uamiHasAppAdminRole}))]"
                             },
                             {
                                 "name": "aadClientSecret",
@@ -169,7 +170,8 @@
                                     "required": true,
                                     "regex": "^.{8,}$",
                                     "validationMessage": "A valid client secret is required."
-                                }
+                                },
+                                "visible": "[not(bool(${uamiHasAppAdminRole}))]"
                             },
                             {
                                 "name": "aadObjectId",
@@ -181,7 +183,7 @@
                                     "regex": "^[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}$",
                                     "validationMessage": "The object ID must be a valid global unique identifier (GUID). Example: 00000000-0000-0000-0000-000000000000"
                                 },
-                                "visible": "[bool(${require.objectId})]"
+                                "visible": "[not(bool(${uamiHasAppAdminRole}))]"
                             },
                             {
                                 "name": "rpObjectId",
@@ -193,7 +195,7 @@
                                     "regex": "^[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}$",
                                     "validationMessage": "The object ID must be a valid global unique identifier (GUID). Example: 00000000-0000-0000-0000-000000000000"
                                 },
-                                "visible": "[bool(${require.objectId})]"
+                                "visible": "[not(bool(${uamiHasAppAdminRole}))]"
                             }
                         ],
                         "visible": "[bool(steps('Cluster').createCluster)]"

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -136,14 +136,14 @@
                                 "name": "pullSecret",
                                 "type": "Microsoft.Common.PasswordBox",
                                 "label": {
-                                    "password": "Pull secret",
+                                    "password": "Red Hat pull secret",
                                     "confirmPassword": "Confirm secret"
                                 },
                                 "toolTip": "The pull secret text that you obtained from the Red Hat OpenShift Cluster Manager website.<br><br>To get pull secret text, see <a href='https://docs.microsoft.com/azure/openshift/tutorial-create-cluster#get-a-red-hat-pull-secret-optional' target='_blank'>Get a Red Hat pull secret</a>.",
                                 "constraints": {
                                     "required": true,
                                     "regex": "^.{8,}$",
-                                    "validationMessage": "A valid pull secret is required."
+                                    "validationMessage": "A valid Red Hat pull secret is required."
                                 }
                             },
                             {

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -7,10 +7,10 @@
             {
                 "name": "errInfo",
                 "type": "Microsoft.Common.InfoBox",
-                "visible": "[less(length(basics('identity').userAssignedIdentities), 1)]",
+                "visible": "[not(equals(length(basics('identity').userAssignedIdentities), 1))]",
                 "options": {
                     "icon": "Error",
-                    "text": "[concat('Select one user-assigned managed identity that has a <b>Contributor</b> role in the subscription', if(bool(${uamiHasAppAdminRole}), ' and an <b>Application administrator</b> role in Azure AD', ''), '.<br><br>You can find more details from the following articles:<li><a href=\\'https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity\\' target=\\'_blank\\'>Create a user-assigned managed identity</a></li><li><a href=\\'https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity\\' target=\\'_blank\\'>Assign a role to a user-assigned managed identity</a></li>', if(bool(${uamiHasAppAdminRole}), '<li><a href=\\'https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role\\' target=\\'_blank\\'>Assign Azure AD roles to a user-assigned managed identity</a></li>', ''))]"
+                    "text": "[concat('Select <b>only one</b> user-assigned managed identity that has a <b>Contributor</b> role in the subscription', if(bool(${uamiHasAppAdminRole}), ' and an <b>Application administrator</b> role in Azure AD', ''), '.<br><br>You can find more details from the following articles:<li><a href=\\'https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity\\' target=\\'_blank\\'>Create a user-assigned managed identity</a></li><li><a href=\\'https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity\\' target=\\'_blank\\'>Assign a role to a user-assigned managed identity</a></li>', if(bool(${uamiHasAppAdminRole}), '<li><a href=\\'https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role\\' target=\\'_blank\\'>Assign Azure AD roles to a user-assigned managed identity</a></li>', ''))]"
                 }
             },
             {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -73,7 +73,7 @@
             "type": "string",
             "defaultValue": "",
             "metadata": {
-                "description": "The Application ID of an Azure Active Directory client application"
+                "description": "The application ID of an Azure Active Directory client application"
             }
         },
         "aadClientSecret": {
@@ -87,14 +87,14 @@
             "type": "string",
             "defaultValue": "",
             "metadata": {
-                "description": "The Object ID of an Azure Active Directory client application"
+                "description": "The service principal Object ID of an Azure Active Directory client application"
             }
         },
         "rpObjectId": {
             "type": "String",
             "defaultValue": "",
             "metadata": {
-                "description": "The Object ID of the Resource Provider Service Principal"
+                "description": "The service principal Object ID of the Azure Red Hat OpenShift Resource Provider"
             }
         },
         "masterVmSize": {
@@ -155,10 +155,12 @@
         },
         "guidValue": {
             "defaultValue": "[newGuid()]",
-            "type": "string"
+            "type": "securestring"
         }
     },
     "variables": {
+        "const_aadClientName": "[concat('aadclient', variables('const_suffix'))]",
+        "const_aadClientSecret": "[if(and(parameters('createCluster'), empty(parameters('aadClientSecret'))), guid(skip(replace(parameters('guidValue'), '-', ''), 6)), parameters('aadClientSecret'))]",
         "const_appImage": "[concat(variables('const_appImageName'), ':', variables('const_appImageTag'))]",
         "const_appImageName": "[concat('image', variables('const_suffix'))]",
         "const_appImageTag": "1.0.0",
@@ -174,8 +176,8 @@
         "const_suffix": "[take(replace(parameters('guidValue'), '-', ''), 6)]",
         "name_clusterName": "[if(parameters('createCluster'), concat('cluster', variables('const_suffix')), parameters('clusterName'))]",
         "name_clusterVNetName": "[concat('vnet', variables('const_suffix'))]",
-        "name_deploymentScriptName": "[concat('script', variables('const_suffix'))]",
-        "name_getObjectIdDeploymentScriptName": "[concat('getObjectIdScript', variables('const_suffix'))]"
+        "name_deploymentScriptName": "[concat('aroscript', variables('const_suffix'))]",
+        "name_spDeploymentScript": "[concat('spScript', variables('const_suffix'))]"
     },
     "resources": [
         {
@@ -207,17 +209,26 @@
             }
         },
         {
-            "condition": "[and(parameters('createCluster'), empty(parameters('aadObjectId')), empty(parameters('rpObjectId')))]",
+            "condition": "[and(parameters('createCluster'), or(empty(parameters('aadClientId')), empty(parameters('aadClientSecret')), empty(parameters('aadObjectId')), empty(parameters('rpObjectId'))))]",
             "type": "Microsoft.Resources/deploymentScripts",
             "apiVersion": "${azure.apiVersion.deploymentScript}",
-            "name": "[variables('name_getObjectIdDeploymentScriptName')]",
+            "name": "[variables('name_spDeploymentScript')]",
             "location": "[parameters('location')]",
             "kind": "AzureCLI",
             "identity": "[parameters('identity')]",
             "properties": {
                 "AzCliVersion": "2.15.0",
-                "arguments": "[parameters('aadClientId')]",
-                "primaryScriptUri": "[uri(variables('const_scriptLocation'), concat('get-object-id.sh', parameters('_artifactsLocationSasToken')))]",
+                "environmentVariables": [
+                    {
+                        "name": "AAD_CLIENT_NAME",
+                        "value": "[variables('const_aadClientName')]"
+                    },
+                    {
+                        "name": "AAD_CLIENT_SECRET",
+                        "secureValue": "[variables('const_aadClientSecret')]"
+                    }
+                ],
+                "primaryScriptUri": "[uri(variables('const_scriptLocation'), concat('create-sp.sh', parameters('_artifactsLocationSasToken')))]",
                 "cleanupPreference": "OnSuccess",
                 "retentionInterval": "P1D"
             }
@@ -229,7 +240,7 @@
             "name": "[variables('name_clusterVNetName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Resources/deploymentScripts', variables('name_getObjectIdDeploymentScriptName'))]"
+                "[resourceId('Microsoft.Resources/deploymentScripts', variables('name_spDeploymentScript'))]"
             ],
             "properties": {
                 "addressSpace": {
@@ -274,7 +285,7 @@
             ],
             "properties": {
                 "roleDefinitionId": "[variables('const_contribRole')]",
-                "principalId": "[if(and(parameters('createCluster'), empty(parameters('aadObjectId'))), reference(variables('name_getObjectIdDeploymentScriptName')).outputs.appSpObjectId, parameters('aadObjectId'))]"
+                "principalId": "[if(and(parameters('createCluster'), empty(parameters('aadObjectId'))), reference(variables('name_spDeploymentScript')).outputs.appSpObjectId, parameters('aadObjectId'))]"
             }
         },
         {
@@ -287,7 +298,7 @@
             ],
             "properties": {
                 "roleDefinitionId": "[variables('const_contribRole')]",
-                "principalId": "[if(and(parameters('createCluster'), empty(parameters('rpObjectId'))), reference(variables('name_getObjectIdDeploymentScriptName')).outputs.aroRpSpObjectId, parameters('rpObjectId'))]"
+                "principalId": "[if(and(parameters('createCluster'), empty(parameters('rpObjectId'))), reference(variables('name_spDeploymentScript')).outputs.aroRpSpObjectId, parameters('rpObjectId'))]"
             }
         },
         {
@@ -310,8 +321,8 @@
                     "serviceCidr": "172.30.0.0/16"
                 },
                 "servicePrincipalProfile": {
-                    "clientId": "[parameters('aadClientId')]",
-                    "clientSecret": "[parameters('aadClientSecret')]"
+                    "clientId": "[if(and(parameters('createCluster'), empty(parameters('aadClientId'))), reference(variables('name_spDeploymentScript')).outputs.appClientId, parameters('aadClientId'))]",
+                    "clientSecret": "[variables('const_aadClientSecret')]"
                 },
                 "masterProfile": {
                     "vmSize": "[parameters('masterVmSize')]",

--- a/src/main/arm/parameters.json
+++ b/src/main/arm/parameters.json
@@ -28,12 +28,6 @@
         "projMgrPassword": {
             "value": "${projMgrPassword}"
         },
-        "aadClientId": {
-            "value": "${aadClientId}"
-        },
-        "aadClientSecret": {
-            "value": "${aadClientSecret}"
-        },
         "uploadAppPackage": {
             "value": "${uploadAppPackage}"
         },

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -21,11 +21,13 @@ IFS=$'\n\t'
 # -o: prevents errors in a pipeline from being masked
 # IFS new value is less likely to cause confusing bugs when looping arrays or arguments (e.g. $@)
 
-usage() { echo "Usage: $0 -n <deploymentName> -f <appPackage> -p <pullSecretFile> -a <aadObjectId> -r <rpObjectId> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
+usage() { echo "Usage: $0 -n <deploymentName> -f <appPackage> -p <pullSecretFile> -c <aadClientId> -s <aadClientSecret> -a <aadObjectId> -r <rpObjectId> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
 
 declare deploymentName=""
 declare appPackage=""
 declare pullSecretFile=""
+declare aadClientId=""
+declare aadClientSecret=""
 declare aadObjectId=""
 declare rpObjectId=""
 declare subscriptionId=""
@@ -33,7 +35,7 @@ declare resourceGroupName=""
 declare resourceGroupLocation=""
 
 # Initialize parameters specified from command line
-while getopts ":n:f:p:i:g:l:a:r:" arg; do
+while getopts ":n:f:p:i:g:l:c:s:a:r:" arg; do
 	case "${arg}" in
 		n)
 			deploymentName=${OPTARG}
@@ -43,6 +45,12 @@ while getopts ":n:f:p:i:g:l:a:r:" arg; do
 			;;
 		p)
 			pullSecretFile=${OPTARG}
+			;;
+		c)
+			aadClientId=${OPTARG}
+			;;
+		s)
+			aadClientSecret=${OPTARG}
 			;;
 		a)
 			aadObjectId=${OPTARG}
@@ -241,6 +249,8 @@ appReplicas=$( echo $parametersJson | jq '.appReplicas.value' | sed 's/"//g' )
 parametersJson=$( echo $parametersJson | jq --argjson replicas "$appReplicas" '.appReplicas.value = $replicas' )
 parametersJson=$( echo "$parametersJson" | jq --arg uri "$appPackageUrl" '{"appPackageUrl": {"value":$uri}} + .' )
 parametersJson=$( echo "$parametersJson" | jq --arg pullSecret "$pullSecret" '{"pullSecret": {"value":$pullSecret}} + .' )
+parametersJson=$( echo "$parametersJson" | jq --arg aadClientId "$aadClientId" '{"aadClientId": {"value":$aadClientId}} + .' )
+parametersJson=$( echo "$parametersJson" | jq --arg aadClientSecret "$aadClientSecret" '{"aadClientSecret": {"value":$aadClientSecret}} + .' )
 parametersJson=$( echo "$parametersJson" | jq --arg aadObjectId "$aadObjectId" '{"aadObjectId": {"value":$aadObjectId}} + .' )
 parametersJson=$( echo "$parametersJson" | jq --arg rpObjectId "$rpObjectId" '{"rpObjectId": {"value":$rpObjectId}} + .' )
 parametersJson=$( echo "$parametersJson" | jq -c '.' )

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -207,16 +207,20 @@ fi
 
 # Upload application package to storage container
 fileName=$(basename "$appPackage")
-if [[ $( az storage blob exists -n "$fileName" -c "$storageContainerName" --account-name "$storageAccountName" --account-key "$storageAccountKey" -o json | jq '.exists') = false ]]; then
-	echo "Storage blob with name" $fileName "could not be found. Creating new storage blob..."
+if [[ $( az storage blob exists -n "$fileName" -c "$storageContainerName" --account-name "$storageAccountName" --account-key "$storageAccountKey" -o json | jq '.exists') = true ]]; then
+    echo "Storage blob with name ${fileName} already existed. Deleting it..."
 	set -e
 	(
 		set -x
-		az storage blob upload -f "$appPackage" -c $storageContainerName -n "$fileName" --account-name "$storageAccountName" --account-key "$storageAccountKey"
+		az storage blob delete -c $storageContainerName -n "$fileName" --account-name "$storageAccountName" --account-key "$storageAccountKey"
 	)
-else
-	echo "Using existing storage blob..."
 fi
+echo "Creating blob with name ${fileName}..."
+set -e
+(
+    set -x
+    az storage blob upload -f "$appPackage" -c $storageContainerName -n "$fileName" --account-name "$storageAccountName" --account-key "$storageAccountKey"
+)
 
 set +u
 

--- a/src/main/cli/uploadApp.azcli
+++ b/src/main/cli/uploadApp.azcli
@@ -133,16 +133,20 @@ fi
 
 # Upload application package to storage container
 fileName=$(basename "$appPackage")
-if [[ $( az storage blob exists -n "$fileName" -c "$storageContainerName" --account-name "$storageAccountName" --account-key "$storageAccountKey" -o json | jq '.exists') = false ]]; then
-	echo "Storage blob with name" $fileName "could not be found. Creating new storage blob..."
+if [[ $( az storage blob exists -n "$fileName" -c "$storageContainerName" --account-name "$storageAccountName" --account-key "$storageAccountKey" -o json | jq '.exists') = true ]]; then
+    echo "Storage blob with name ${fileName} already existed. Deleting it..."
 	set -e
 	(
 		set -x
-		az storage blob upload -f "$appPackage" -c $storageContainerName -n "$fileName" --account-name "$storageAccountName" --account-key "$storageAccountKey"
+		az storage blob delete -c $storageContainerName -n "$fileName" --account-name "$storageAccountName" --account-key "$storageAccountKey"
 	)
-else
-	echo "Using existing storage blob..."
 fi
+echo "Creating blob with name ${fileName}..."
+set -e
+(
+    set -x
+    az storage blob upload -f "$appPackage" -c $storageContainerName -n "$fileName" --account-name "$storageAccountName" --account-key "$storageAccountKey"
+)
 
 set +u
 


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #28

## Change summary

* Create service principal within deploymentScript
* Update label from `Pull secret` to `Red Hat pull secret`
* Show error msg if none or multiple UAMIs are selected
* Remove existing app package from storage account before uploading

## Testing

The following test cases have already been passed before opening the PR:

* Failed to create service principal with deploymentScript if the user-assigned managed identity doesn't have an application administrator role in Azure AD;
* Successfully deployed a Java app on an ARO cluster with client ID/client secret/object IDs retrieved by deploymentScript if the user-assigned managed identity has an application administrator role in Azure AD;
* Successfully deployed a Java app on an ARO cluster with user input client ID/client secret/object IDs;

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>