### PR TITLE
Wait until the route of container registry is available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.22</version>
+    <version>1.0.23</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #35 

## Change summary

* Wait until the `default-route` is available.

## Testing

The following test cases have already been passed before opening the PR:

* Deploy a new ARO 4 cluster + deploy an application with user specified image path;
* Deploy a new ARO 4 cluster + no application deployed;

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>