### PR TITLE
Add trigger typ to repository_dispatch

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -6,6 +6,11 @@ on:
   # REPO_NAME=WASdev/azure.liberty.aro
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/package.yaml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
+    types: [package]
+  # sample request
+  # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
+  # REPO_NAME=WASdev/azure.liberty.aro
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
   refArmttk: d97aa57d259e2fc8562e11501b1cf902265129d9
   refJavaee: 85d5d10dd045a90452ae01cad20b258ce853ec18


### PR DESCRIPTION
Add repository dispatch type to tighten the trigger.

Test run: https://github.com/zhengchang907/azure.liberty.aro/actions/runs/1410415692

Signed-off-by: Zheng Chang <zhengchang@microsoft.com>