### PR TITLE
Check the permission of the uami

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.23</version>
+    <version>1.0.24</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/create-sp.sh
+++ b/src/main/scripts/create-sp.sh
@@ -33,7 +33,7 @@ principalId=$(az identity show --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY} --quer
 # Check if the user assigned managed identity has Contributor or Owner role
 roleLength=$(az role assignment list --assignee ${principalId} | jq '.[] | [select(.roleDefinitionName=="Contributor" or .roleDefinitionName=="Owner")] | length')
 if [ ${roleLength} -lt 1 ]; then
-    echo "The user-assigned managed identity must has Contributor or Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+    echo "The user-assigned managed identity must have Contributor or Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
     exit 1
 fi
 

--- a/src/main/scripts/create-sp.sh
+++ b/src/main/scripts/create-sp.sh
@@ -14,6 +14,29 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# Get the type of managed identity
+uamiType=$(az identity show --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY} --query "type" -o tsv)
+if [ $? == 1 ]; then
+    echo "The user-assigned managed identity may not exist or has no access to the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+    exit 1
+fi
+
+# Check if the managed identity is a user-assigned managed identity
+if [[ "${uamiType}" != "Microsoft.ManagedIdentity/userAssignedIdentities" ]]; then
+    echo "You must select a user-assigned managed identity instead of other types, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+    exit 1
+fi
+
+# Query principal Id of the user-assigned managed identity
+principalId=$(az identity show --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY} --query "principalId" -o tsv)
+
+# Check if the user assigned managed identity has Contributor or Owner role
+roleLength=$(az role assignment list --assignee ${principalId} | jq '.[] | [select(.roleDefinitionName=="Contributor" or .roleDefinitionName=="Owner")] | length')
+if [ ${roleLength} -lt 1 ]; then
+    echo "The user-assigned managed identity must has Contributor or Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+    exit 1
+fi
+
 # Create client application and service principal
 app=$(az ad app create --display-name ${AAD_CLIENT_NAME} --password ${AAD_CLIENT_SECRET})
 if [[ $? != 0 ]]; then


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #44

## Change summary

* Enhance deployment script `create-sp.sh` to check if Contributor role (or Owner role) is granted to the uami before deploying Azure resources

## Testing

The following test cases have already been passed before opening the PR:

* The uami has no access to the subscription: Deployment failed fast
* The uami has Reader role in the subscription: Deployment failed fast
* The uami has Contributor role in the subscription: Deployment succeeded

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>