### PR TITLE
Always check if the uami has the required permission in the subscription and check if source image is valid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.25</version>
+    <version>1.0.27</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.24</version>
+    <version>1.0.25</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -327,13 +327,13 @@
                             {
                                 "name": "appImagePath",
                                 "type": "Microsoft.Common.TextBox",
-                                "label": "Application docker image path",
+                                "label": "Application container image path",
                                 "placeholder": "Example: docker.io/openliberty/open-liberty:full-java11-openj9-ubi",
-                                "toolTip": "Specify the docker image path of your application.",
+                                "toolTip": "Specify the container image path of your application.",
                                 "constraints": {
                                     "required": true,
                                     "regex": "^(?:(?=[^:\/]{4,253})(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*(?::[0-9]{1,5})?/)?((?![._-])(?:[a-z0-9._-]*)(?<![._-])(?:/(?![._-])[a-z0-9._-]*(?<![._-]))*)(?::(?![.-])[a-zA-Z0-9_.-]{1,128})?$",
-                                    "validationMessage": "The value must be a valid docker image path. For example, docker.io/openliberty/open-liberty:full-java11-openj9-ubi"
+                                    "validationMessage": "The value must be a valid container image path. For example, docker.io/openliberty/open-liberty:full-java11-openj9-ubi"
                                 },
                                 "visible": "[or(not(bool(${samples.available})), equals(steps('Application').appImageInfo.appImageOption, '1'))]"
                             }

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -316,9 +316,19 @@
                                 "visible": "[bool(${samples.available})]"
                             },
                             {
+                                "name": "imagePathInfo",
+                                "type": "Microsoft.Common.InfoBox",
+                                "options": {
+                                    "icon": "Info",
+                                    "text": "Please provide a public image which is accessible without credentials."
+                                },
+                                "visible": "[or(not(bool(${samples.available})), equals(steps('Application').appImageInfo.appImageOption, '1'))]"
+                            },
+                            {
                                 "name": "appImagePath",
                                 "type": "Microsoft.Common.TextBox",
                                 "label": "Application docker image path",
+                                "placeholder": "Example: docker.io/openliberty/open-liberty:full-java11-openj9-ubi",
                                 "toolTip": "Specify the docker image path of your application.",
                                 "constraints": {
                                     "required": true,

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -191,7 +191,6 @@
             }
         },
         {
-            "condition": "[and(parameters('createCluster'), or(empty(parameters('aadClientId')), empty(parameters('aadClientSecret')), empty(parameters('aadObjectId')), empty(parameters('rpObjectId'))))]",
             "type": "Microsoft.Resources/deploymentScripts",
             "apiVersion": "${azure.apiVersion.deploymentScript}",
             "name": "[variables('name_spDeploymentScript')]",
@@ -201,6 +200,10 @@
             "properties": {
                 "AzCliVersion": "2.15.0",
                 "environmentVariables": [
+                    {
+                        "name": "CREATE_AAD_CLIENT",
+                        "value": "[and(parameters('createCluster'), or(empty(parameters('aadClientId')), empty(parameters('aadClientSecret')), empty(parameters('aadObjectId')), empty(parameters('rpObjectId'))))]"
+                    },
                     {
                         "name": "AAD_CLIENT_NAME",
                         "value": "[variables('const_aadClientName')]"

--- a/src/main/scripts/create-sp.sh
+++ b/src/main/scripts/create-sp.sh
@@ -37,6 +37,11 @@ if [ ${roleLength} -lt 1 ]; then
     exit 1
 fi
 
+# Check if client application needs to be created
+if [[ ${CREATE_AAD_CLIENT} != "True" ]]; then
+    exit 0
+fi
+
 # Create client application and service principal
 app=$(az ad app create --display-name ${AAD_CLIENT_NAME} --password ${AAD_CLIENT_SECRET})
 if [[ $? != 0 ]]; then

--- a/src/main/scripts/import-image.sh
+++ b/src/main/scripts/import-image.sh
@@ -22,19 +22,19 @@ appProjName=$5
 appImage=$6
 
 # Install docker and start docker daemon
-apt-get -q update
-apt-get -y -q install apt-transport-https
+apt-get -q update >/dev/null 2>&1
+apt-get -y -q install apt-transport-https >/dev/null 2>&1
 curl -m 120 -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
-apt-get -q update
-apt-get -y -q install docker-ce docker-ce-cli containerd.io
+apt-get -q update >/dev/null 2>&1
+apt-get -y -q install docker-ce docker-ce-cli containerd.io >/dev/null 2>&1
 systemctl start docker
 
 # Pull and tag image
-docker pull ${sourceImagePath}
+docker pull ${sourceImagePath} 1>/dev/null
 docker tag ${sourceImagePath} ${registryHost}/${appProjName}/${appImage}
 
 # Sign in to the built-in container image registry and push image
-docker login -u ${registryUsername} -p ${registryPassword} ${registryHost}
-docker push ${registryHost}/${appProjName}/${appImage}
+docker login -u ${registryUsername} -p ${registryPassword} ${registryHost} >/dev/null 2>&1
+docker push ${registryHost}/${appProjName}/${appImage} 1>/dev/null

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -284,6 +284,13 @@ if [ "$deployApplication" = True ]; then
     az group delete -n ${vmGroupName} -y
     echo "VM deleted at $(date)." >> $logFile
 
+    # Check whether the source image is successfully imported to the built-in container registry
+    oc get imagestreamtag ${Application_Image} --namespace ${Project_Name}
+    if [[ $? != 0 ]]; then
+        echo "Unable to import source image ${sourceImagePath} to the built-in container registry of the OpenShift cluster. Please check if it's a public image and the source image path is correct" >&2
+        exit 1
+    fi
+
     # Deploy open liberty application and output its base64 encoded deployment yaml file content
     envsubst < "open-liberty-application.yaml.template" > "open-liberty-application.yaml"
     appDeploymentYaml=$(cat open-liberty-application.yaml | base64)

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -250,7 +250,7 @@ if [ "$deployApplication" = True ]; then
     registryPassword=$(oc whoami -t)
     echo "registryUsername: $registryUsername" >> $logFile
 
-    # Create vm to import docker image to the built-in container registry of the OpenShift cluster
+    # Create vm to import container image to the built-in container registry of the OpenShift cluster
     vmName="VM-UBUNTU-IMAGE-BUILDER-$(date +%s)"
     vmGroupName=${Application_Name}-$(date +%s)
     vmRegion=$(az aro show -g $clusterRGName -n $clusterName --query 'location' -o tsv)


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Follow-up for PR #45
* Resolve #47 

## Change summary

* Whether uami has the required permission in the subscription is always checked
* Only create the client application when required
* Add image path example as placeholder text
* Request a public image in the info box
* Check if the source image is valid and exit with the appropriate error message if not
* Remove unnecessary error messages from the list when the deployment failed 

## Testing

The following test cases have already been passed before opening the PR:

* Successfully deployed the application with the user specified docker image path: `websphere-liberty`
* Failed to deploy the application with the incorrect docker image path: `websphere-liberty-not-found`

Screenshot for the enhanced **Configure application** blade:
![image](https://user-images.githubusercontent.com/10357495/145163902-ff954224-c1e1-44e0-b2a6-27f6c0364cc5.png)

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>