### PR TITLE
upgrade open-liberty-operator to 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.27</version>
+    <version>1.0.28</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.28</version>
+    <version>1.0.29</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -193,7 +193,7 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-# Install Open Liberty Operator V0.7.0
+# Install Open Liberty Operator
 wait_subscription_created open-liberty-certified openshift-operators ${logFile}
 if [[ $? -ne 0 ]]; then
   echo "Failed to install the Open Liberty Operator from the OperatorHub." >&2

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -199,7 +199,7 @@ if [[ $? -ne 0 ]]; then
   echo "Failed to install the Open Liberty Operator from the OperatorHub." >&2
   exit 1
 fi
-wait_deployment_complete open-liberty-operator openshift-operators ${logFile}
+wait_deployment_complete olo-controller-manager openshift-operators ${logFile}
 if [[ $? -ne 0 ]]; then
   echo "The Open Liberty Operator is not available." >&2
   exit 1

--- a/src/main/scripts/open-liberty-application.yaml.template
+++ b/src/main/scripts/open-liberty-application.yaml.template
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-apiVersion: openliberty.io/v1beta1
+apiVersion: apps.openliberty.io/v1beta2
 kind: OpenLibertyApplication
 metadata:
   name: ${Application_Name}

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -4,9 +4,9 @@ metadata:
   name: open-liberty-certified
   namespace: openshift-operators
 spec:
-  channel: beta
+  channel: beta2
   installPlanApproval: Automatic
   name: open-liberty-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: open-liberty-operator.v0.7.0
+  startingCSV: open-liberty-operator.v0.8.0


### PR DESCRIPTION
The PR is to resolve #49 by upgrading open-liberty-operator to 0.8.0.

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>