### PR TITLE
Add delay to wait sp available for role assignment in ARM template

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.32</version>
+    <version>1.0.33</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/create-sp.sh
+++ b/src/main/scripts/create-sp.sh
@@ -62,6 +62,10 @@ if [[ $? != 0 ]]; then
   echo "Failed to get service principal object ID for ${appClientId}." >&2
   exit 1
 fi
+
+# Wait 30s for service principal available after creation. See https://github.com/WASdev/azure.liberty.aro/issues/59.
+sleep 30
+
 aroRpSpObjectId=$(az ad sp list --display-name "Azure Red Hat OpenShift RP" --query '[0].objectId' -o tsv)
 if [[ $? != 0 ]]; then
   echo "Failed to get service principal object ID for \"Azure Red Hat OpenShift RP\"." >&2


### PR DESCRIPTION
The PR is to resolve #59. Based on the analysis of issue #59 , the PR is to add a delay (30s) after sp is created, in order to wait it available for role assignment in the ARM template later.

## Testing

Tested for 5 times, the role assignment to the created service principal all succeeded.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>