### PR TITLE
Increase max retries to wait until the Open Liberty Operator is available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.33</version>
+    <version>1.0.34</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-MAX_RETRIES=99
+MAX_RETRIES=299
 
 wait_login_complete() {
     username=$1

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -14,6 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# See https://github.com/WASdev/azure.liberty.aro/issues/60
 MAX_RETRIES=299
 
 wait_login_complete() {


### PR DESCRIPTION
The PR is to increase the max retries in order to wait until the Open Liberty Operator is available, to resolve #60.

## Testing

Tested for 5 times, all deployments succeeded.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>