### PR TITLE
Fix the issue that the app image is not successfully deployed

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -13,7 +13,7 @@ on:
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
   refArmttk: d97aa57d259e2fc8562e11501b1cf902265129d9
-  refJavaee: 85d5d10dd045a90452ae01cad20b258ce853ec18
+  refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
   repoName: "azure.liberty.aro"
 
 jobs:

--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,12 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.36</version>
+    <version>1.0.37</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.11</version>
+        <version>1.0.16</version>
         <relativePath></relativePath>
     </parent>
     
@@ -33,6 +33,8 @@
     <name>${project.artifactId}</name>
 
     <properties>
+        <git.repo>WASdev</git.repo>
+        <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
         <test.parameters>-TestParameter '@{&quot;PasswordMinLength&quot;=6}'</test.parameters>
         <azure.apiVersion>2020-06-01</azure.apiVersion>
         <azure.apiVersion.vNetRoleAssignment>2018-09-01-preview</azure.apiVersion.vNetRoleAssignment>

--- a/src/main/arm/parameters.json
+++ b/src/main/arm/parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "_artifactsLocation": {
-            "value": "${artifactsLocationBase}/${project.artifactId}/${git.tag}/src/main/"
+            "value": "${artifactsLocationBase}/src/main/"
         },
         "identity": {
             "value": {

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -319,13 +319,13 @@ if [ "$deployApplication" = True ]; then
         exit 1
     fi
 
-    # Get the host of the route to visit the deployed application
+    # Get the host of the route which is assigned to variable 'appEndpoint' inside function 'wait_route_available'
+    appEndpoint=
     wait_route_available ${Application_Name} ${Project_Name} $logFile
     if [[ $? -ne 0 ]]; then
         echo "The route ${Application_Name} is not available." >&2
         exit 1
     fi
-    appEndpoint=$(oc get route ${Application_Name} -n ${Project_Name} -o=jsonpath='{.spec.host}')
     echo "appEndpoint is ${appEndpoint}"
 else
     # Output base64 encoded deployment template yaml file content

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -158,12 +158,12 @@ wait_deployment_complete() {
 }
 
 wait_project_created() {
-    projectName=$1
+    namespaceName=$1
     logFile=$2
 
     cnt=0
-    oc new-project ${projectName} 2>/dev/null
-    oc get project ${projectName} 2>/dev/null
+    oc new-project ${namespaceName} 2>/dev/null
+    oc get project ${namespaceName} 2>/dev/null
     while [ $? -ne 0 ]
     do
         if [ $cnt -eq $MAX_RETRIES ]; then
@@ -172,22 +172,22 @@ wait_project_created() {
         fi
         cnt=$((cnt+1))
 
-        echo "Unable to create the project ${projectName}, retry ${cnt} of ${MAX_RETRIES}..." >> $logFile
+        echo "Unable to create the project ${namespaceName}, retry ${cnt} of ${MAX_RETRIES}..." >> $logFile
         sleep 5
-        oc new-project ${projectName} 2>/dev/null
-        oc get project ${projectName} 2>/dev/null
+        oc new-project ${namespaceName} 2>/dev/null
+        oc get project ${namespaceName} 2>/dev/null
     done
 }
 
 wait_image_imported() {
     appImage=$1
     sourceImagePath=$2
-    projectName=$3
+    namespaceName=$3
     logFile=$4
 
     cnt=0
-    oc import-image ${appImage} --from=${sourceImagePath} --namespace ${projectName} --reference-policy=local --confirm 2>/dev/null
-    oc get imagestreamtag ${appImage} --namespace ${projectName} 2>/dev/null
+    oc import-image ${appImage} --from=${sourceImagePath} --namespace ${namespaceName} --reference-policy=local --confirm 2>/dev/null
+    oc get imagestreamtag ${appImage} --namespace ${namespaceName} 2>/dev/null
     while [ $? -ne 0 ]
     do
         if [ $cnt -eq $MAX_RETRIES ]; then
@@ -198,8 +198,8 @@ wait_image_imported() {
 
         echo "Unable to import source image ${sourceImagePath}, retry ${cnt} of ${MAX_RETRIES}..." >> $logFile
         sleep 5
-        oc import-image ${appImage} --from=${sourceImagePath} --namespace ${projectName} --reference-policy=local --confirm 2>/dev/null
-        oc get imagestreamtag ${appImage} --namespace ${projectName} 2>/dev/null
+        oc import-image ${appImage} --from=${sourceImagePath} --namespace ${namespaceName} --reference-policy=local --confirm 2>/dev/null
+        oc get imagestreamtag ${appImage} --namespace ${namespaceName} 2>/dev/null
     done
 }
 

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -204,8 +204,8 @@ wait_route_available() {
     done
 
     cnt=0
-    appEndpoint=$(oc get route ${routeName} -n ${namespaceName} --template='{{ .spec.host }}')
-    echo "appEndpoint is ${appEndpoint}" >> $logFile
+    appEndpoint=$(oc get route ${routeName} -n ${namespaceName} --template='{{ .spec.host }}' | xargs)
+    echo "appEndpoint is ${appEndpoint}"
     while [[ -z $appEndpoint ]]
     do
         if [ $cnt -eq $MAX_RETRIES ]; then
@@ -215,8 +215,8 @@ wait_route_available() {
         cnt=$((cnt+1))
         sleep 5
         echo "Wait until the host of route ${routeName} is available, retry ${cnt} of ${MAX_RETRIES}..." >> $logFile
-        appEndpoint=$(oc get route ${routeName} -n ${namespaceName} --template='{{ .spec.host }}')
-        echo "appEndpoint is ${appEndpoint}" >> $logFile
+        appEndpoint=$(oc get route ${routeName} -n ${namespaceName} --template='{{ .spec.host }}' | xargs)
+        echo "appEndpoint is ${appEndpoint}"
     done
 }
 

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -302,6 +302,7 @@ if [ "$deployApplication" = True ]; then
         exit 1
     fi
     appEndpoint=$(oc get route ${Application_Name} -n ${Project_Name} -o=jsonpath='{.spec.host}')
+    echo "appEndpoint is ${appEndpoint}"
 else
     # Output base64 encoded deployment template yaml file content
     appDeploymentYaml=$(cat open-liberty-application.yaml.template | sed -e "s/\${Project_Name}/${Project_Name}/g" -e "s/\${Application_Replicas}/${Application_Replicas}/g" | base64)

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -202,6 +202,22 @@ wait_route_available() {
         sleep 5
         oc get route ${routeName} -n ${namespaceName} 2>/dev/null
     done
+
+    cnt=0
+    appEndpoint=$(oc get route ${routeName} -n ${namespaceName} --template='{{ .spec.host }}')
+    echo "appEndpoint is ${appEndpoint}" >> $logFile
+    while [[ -z $appEndpoint ]]
+    do
+        if [ $cnt -eq $MAX_RETRIES ]; then
+            echo "Timeout and exit due to the maximum retries reached." >> $logFile 
+            return 1
+        fi
+        cnt=$((cnt+1))
+        sleep 5
+        echo "Wait until the host of route ${routeName} is available, retry ${cnt} of ${MAX_RETRIES}..." >> $logFile
+        appEndpoint=$(oc get route ${routeName} -n ${namespaceName} --template='{{ .spec.host }}')
+        echo "appEndpoint is ${appEndpoint}" >> $logFile
+    done
 }
 
 clusterRGName=$1

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -204,7 +204,7 @@ wait_route_available() {
     done
 
     cnt=0
-    appEndpoint=$(oc get route ${routeName} -n ${namespaceName} --template='{{ .spec.host }}' | xargs)
+    appEndpoint=$(oc get route ${routeName} -n ${namespaceName} -o=jsonpath='{.spec.host}')
     echo "appEndpoint is ${appEndpoint}"
     while [[ -z $appEndpoint ]]
     do
@@ -215,7 +215,7 @@ wait_route_available() {
         cnt=$((cnt+1))
         sleep 5
         echo "Wait until the host of route ${routeName} is available, retry ${cnt} of ${MAX_RETRIES}..." >> $logFile
-        appEndpoint=$(oc get route ${routeName} -n ${namespaceName} --template='{{ .spec.host }}' | xargs)
+        appEndpoint=$(oc get route ${routeName} -n ${namespaceName} -o=jsonpath='{.spec.host}')
         echo "appEndpoint is ${appEndpoint}"
     done
 }
@@ -301,7 +301,7 @@ if [ "$deployApplication" = True ]; then
         echo "The route ${Application_Name} is not available." >&2
         exit 1
     fi
-    appEndpoint=$(oc get route ${Application_Name} --namespace ${Project_Name} --template='{{ .spec.host }}')
+    appEndpoint=$(oc get route ${Application_Name} -n ${Project_Name} -o=jsonpath='{.spec.host}')
 else
     # Output base64 encoded deployment template yaml file content
     appDeploymentYaml=$(cat open-liberty-application.yaml.template | sed -e "s/\${Project_Name}/${Project_Name}/g" -e "s/\${Application_Replicas}/${Application_Replicas}/g" | base64)


### PR DESCRIPTION
## Description

The PR is to resolve #70, with the following changes:

* Add a new method `wait_project_created` with retry mechanism to improve the resilience of creating project/namespace.
* Add a new method `wait_image_imported` with retry mechanism to improve the resilience of importing user specified app image.
* Add a new method `wait_resource_applied` with retry mechanism to improve the resilience of deploying `OpenLibertyApplication` custom resource with user specified app image.
* Enhance the existing method `wait_route_available` with retry mechanism to improve the resilience of getting the route host of deployed app.

## Testing

The following test cases have already been passed before opening the PR:

* Successfully deployed the ARO 4 cluster with the Open Liberty sample image or user specified app image. The route of deployed app is exposed as one of deployment outputs and accessible from the browser.

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>