### PR TITLE
Upgrade versions of external deps used in pipelines by referencing to the centralized config file

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,14 +12,20 @@ on:
   # REPO_NAME=WASdev/azure.liberty.aro
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
-  refArmttk: d97aa57d259e2fc8562e11501b1cf902265129d9
-  refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
   repoName: "azure.liberty.aro"
 
 jobs:
   package:
     runs-on: ubuntu-latest
     steps:
+      - name: Get versions of external dependencies
+        run: |
+          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
+          source external-deps-versions.properties
+          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
+          echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
+          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
+          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Checkout azure-javaee-iaas
         uses: actions/checkout@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.16</version>
+        <version>1.0.18</version>
         <relativePath></relativePath>
     </parent>
     

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.37</version>
+    <version>1.0.38</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
@@ -36,7 +36,7 @@
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
         <test.parameters>-TestParameter '@{&quot;PasswordMinLength&quot;=6}'</test.parameters>
-        <azure.apiVersion.deployments> 2021-04-01</azure.apiVersion.deployments>
+        <azure.apiVersion.deployments>2021-04-01</azure.apiVersion.deployments>
         <azure.apiVersion.virtualNetworks>2022-05-01</azure.apiVersion.virtualNetworks>
         <azure.apiVersion.vNetRoleAssignment>2018-09-01-preview</azure.apiVersion.vNetRoleAssignment>
         <azure.apiVersion.aroCluster>2022-04-01</azure.apiVersion.aroCluster>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.19</version>
+        <version>1.0.18</version>
         <relativePath></relativePath>
     </parent>
     

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.18</version>
+        <version>1.0.19</version>
         <relativePath></relativePath>
     </parent>
     
@@ -36,9 +36,10 @@
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
         <test.parameters>-TestParameter '@{&quot;PasswordMinLength&quot;=6}'</test.parameters>
-        <azure.apiVersion>2020-06-01</azure.apiVersion>
+        <azure.apiVersion.deployments> 2021-04-01</azure.apiVersion.deployments>
+        <azure.apiVersion.virtualNetworks>2022-05-01</azure.apiVersion.virtualNetworks>
         <azure.apiVersion.vNetRoleAssignment>2018-09-01-preview</azure.apiVersion.vNetRoleAssignment>
-        <azure.apiVersion.aroCluster>2020-04-30</azure.apiVersion.aroCluster>
+        <azure.apiVersion.aroCluster>2022-04-01</azure.apiVersion.aroCluster>
         <azure.apiVersion.deploymentScript>2020-10-01</azure.apiVersion.deploymentScript>
         <!--Testing PID <customer.usage.attribution.id>pid-1a2a9b5a-6c82-42de-a938-9fdb6ffe8e55-partnercenter</customer.usage.attribution.id> -->
         <customer.usage.attribution.id>pid-8942a2f7-32d6-4b69-b504-4c2fb23fe059-partnercenter</customer.usage.attribution.id>

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -287,7 +287,8 @@
                 "clusterProfile": {
                     "domain": "[variables('const_clusterDomainName')]",
                     "resourceGroupId": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', concat('MC_', resourceGroup().name, '_', variables('name_clusterName'), '_', parameters('location')))]",
-                    "pullSecret": "[parameters('pullSecret')]"
+                    "pullSecret": "[parameters('pullSecret')]",
+                    "fipsValidatedModules": "Disabled"
                 },
                 "networkProfile": {
                     "podCidr": "10.128.0.0/14",
@@ -299,7 +300,8 @@
                 },
                 "masterProfile": {
                     "vmSize": "[parameters('vmSize')]",
-                    "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_clusterVNetName'), 'master')]"
+                    "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_clusterVNetName'), 'master')]",
+                    "encryptionAtHost": "Disabled"
                 },
                 "workerProfiles": [
                     {
@@ -307,7 +309,8 @@
                         "vmSize": "[parameters('workerVmSize')]",
                         "diskSizeGB": 128,
                         "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_clusterVNetName'), 'worker')]",
-                        "count": 3
+                        "count": 3,
+                        "encryptionAtHost": "Disabled"
                     }
                 ],
                 "apiserverProfile": {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -85,7 +85,7 @@
                 "description": "The service principal Object ID of the Azure Red Hat OpenShift Resource Provider"
             }
         },
-        "masterVmSize": {
+        "vmSize": {
             "type": "string",
             "defaultValue": "Standard_D8s_v3",
             "metadata": {
@@ -298,7 +298,7 @@
                     "clientSecret": "[variables('const_aadClientSecret')]"
                 },
                 "masterProfile": {
-                    "vmSize": "[parameters('masterVmSize')]",
+                    "vmSize": "[parameters('vmSize')]",
                     "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_clusterVNetName'), 'master')]"
                 },
                 "workerProfiles": [

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -152,7 +152,7 @@
     "resources": [
         {
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "${azure.apiVersion}",
+            "apiVersion": "${azure.apiVersion.deployments}",
             "name": "${customer.usage.attribution.id}",
             "properties": {
                 "mode": "Incremental",
@@ -166,7 +166,7 @@
         },
         {
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "${azure.apiVersion}",
+            "apiVersion": "${azure.apiVersion.deployments}",
             "name": "${aro.start}",
             "properties": {
                 "mode": "Incremental",
@@ -209,7 +209,7 @@
         {
            "condition": "[parameters('createCluster')]",
             "type": "Microsoft.Network/virtualNetworks",
-            "apiVersion": "${azure.apiVersion}",
+            "apiVersion": "${azure.apiVersion.virtualNetworks}",
             "name": "[variables('name_clusterVNetName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -345,7 +345,7 @@
         },
         {
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "${azure.apiVersion}",
+            "apiVersion": "${azure.apiVersion.deployments}",
             "name": "${aro.end}",
             "dependsOn": [
                 "[resourceId('Microsoft.Resources/deploymentScripts', variables('name_deploymentScriptName'))]"


### PR DESCRIPTION
Upgrade versions of external deps used in pipelines by referencing to the centralized config file:
- arm-ttk
- azure-javaee-iaas

The other changes:
- upgrade to Azure resource api versions
- work around arm-ttk test 'VMSize parameter must be declared for the parent template'

Successful ran of `package` pipeline:
* https://github.com/majguo/azure.liberty.aro/actions/runs/3269776966

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>