### PR TITLE
Support WebSphere Liberty Operator

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -34,7 +34,7 @@ env:
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
   userName: ${{ secrets.USER_NAME }}
   uamiId: ${{ secrets.UAMI_ID }}
-  pullSecret: ${{ secrets.PULL_SECRET }}
+  pullSecretEncoded: ${{ secrets.PULL_SECRET_ENCODED }}
   msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
   testResourceGroup: libertyAroTestRG${{ github.run_id }}${{ github.run_number }}
   testDeploymentName: libertyAroTestDeployment${{ github.run_id }}${{ github.run_number }}
@@ -98,7 +98,7 @@ jobs:
         run: |
           cd ${{ env.repoName }}/target/cli
           chmod a+x deploy.azcli
-          ./deploy.azcli -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} -l ${{ env.location }} -t ${{ env.pullSecret }}
+          ./deploy.azcli -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} -l ${{ env.location }} -t ${{ env.pullSecretEncoded }}
       - name: Verify the deployment
         run: |
           outputs=$(az deployment group show -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} --query 'properties.outputs')

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -101,8 +101,8 @@ jobs:
           ./deploy.azcli -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} -l ${{ env.location }} -t ${{ env.pullSecretEncoded }}
       - name: Verify the deployment
         run: |
-          outputs=$(az deployment group show -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} --query 'properties.outputs')
-          appEndpoint=$(echo $outputs | jq -r '.appEndpoint.value')
+          clusterName=$(az deployment group show -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} --query 'properties.outputs.clusterName.value' -o tsv)
+          appEndpoint=$(az resource show -n aroscript${clusterName:7} -g ${{ env.testResourceGroup }} --resource-type Microsoft.Resources/deploymentScripts --query "properties.outputs.appEndpoint" -o tsv)
           echo "appEndpoint: ${appEndpoint}"
           if [[ $deployApplication == "true" ]]; then
             if [[ -z "$appEndpoint" ]]; then

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       deployWLO:
-        description: 'WebSphere Liberty operator'
+        description: 'WebSphere Liberty Operator'
         required: true
         type: boolean
         default: false
@@ -20,14 +20,14 @@ on:
   # Allows you to run this workflow using GitHub workflow dispatch APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.liberty.aro
-  # Enable/disable WebSphere Liberty operator and sample application. Keep/delete Azure resources at the end.
+  # Enable/disable WebSphere Liberty Operator and sample application. Keep/delete Azure resources at the end.
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main", "inputs":{"deployWLO": "true|false", "deployApplication": "true|false", "deleteAzureResources": "true|false"}}'
   repository_dispatch:
     types: [integration-test]
   # Allows you to run this workflow using GitHub repository dispatch APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.liberty.aro
-  # Enable/disable WebSphere Liberty operator and sample application. Keep/delete Azure resources at the end.
+  # Enable/disable WebSphere Liberty Operator and sample application. Keep/delete Azure resources at the end.
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"deployWLO": true|false, "deployApplication": true|false, "deleteAzureResources": true|false}}'
 env:
   repoName: "azure.liberty.aro"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,173 @@
+name: integration-test
+on:
+  workflow_dispatch:
+    inputs:
+      deployWLO:
+        description: 'WebSphere Liberty operator'
+        required: true
+        type: boolean
+        default: false
+      deployApplication:
+        description: 'Sample application'
+        required: true
+        type: boolean
+        default: true
+      deleteAzureResources:
+        description: 'Delete Azure resources at the end'
+        required: true
+        type: boolean
+        default: true
+  # Allows you to run this workflow using GitHub workflow dispatch APIs
+  # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
+  # REPO_NAME=WASdev/azure.liberty.aro
+  # Enable/disable WebSphere Liberty operator and sample application. Keep/delete Azure resources at the end.
+  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main", "inputs":{"deployWLO": "true|false", "deployApplication": "true|false", "deleteAzureResources": "true|false"}}'
+  repository_dispatch:
+    types: [integration-test]
+  # Allows you to run this workflow using GitHub repository dispatch APIs
+  # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
+  # REPO_NAME=WASdev/azure.liberty.aro
+  # Enable/disable WebSphere Liberty operator and sample application. Keep/delete Azure resources at the end.
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"deployWLO": true|false, "deployApplication": true|false, "deleteAzureResources": true|false}}'
+env:
+  repoName: "azure.liberty.aro"
+  azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
+  userName: ${{ secrets.USER_NAME }}
+  uamiId: ${{ secrets.UAMI_ID }}
+  pullSecret: ${{ secrets.PULL_SECRET }}
+  msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
+  testResourceGroup: libertyAroTestRG${{ github.run_id }}${{ github.run_number }}
+  testDeploymentName: libertyAroTestDeployment${{ github.run_id }}${{ github.run_number }}
+  location: eastus
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get versions of external dependencies
+        run: |
+          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
+          source external-deps-versions.properties
+          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
+          echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
+          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
+          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Checkout azure-javaee-iaas
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/azure-javaee-iaas
+          path: azure-javaee-iaas
+          ref: ${{ env.refJavaee }}
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
+          ref: ${{ env.refArmttk }}
+      - name: Checkout ${{ env.repoName }}
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.repoName }}
+          ref: ${{ github.event.inputs.ref }}
+      - name: Build azure-javaee-iaas
+        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+      - name: Build ${{ env.repoName }}
+        run: |
+          deployWLO=false
+          if ${{ inputs.deployWLO == true || github.event.client_payload.deployWLO == true }}; then
+            deployWLO=true
+          fi
+          deployApplication=false
+          if ${{ inputs.deployApplication == true || github.event.client_payload.deployApplication == true }}; then
+            deployApplication=true
+          fi
+          echo "deployApplication=${deployApplication}" >> $GITHUB_ENV
+          cd ${{ env.repoName }}
+          mvn -Dgit.repo=${{ env.userName }} -Dgit.tag=$GITHUB_REF_NAME -DidentityId=${{ env.uamiId }} -DcreateCluster=true \
+            -DdeployWLO=${deployWLO} -Dedition="IBM WebSphere Application Server" -DproductEntitlementSource="Standalone" \
+            -DdeployApplication=${deployApplication} -DappImagePath=icr.io/appcafe/open-liberty/samples/getting-started -DappReplicas=2 \
+            -Dtest.args="-Test All" -Passembly -Ptemplate-validation-tests clean install
+      - uses: azure/login@v1
+        id: azure-login
+        with:
+          creds: ${{ env.azureCredentials }}
+      - name: Start the deployment
+        run: |
+          cd ${{ env.repoName }}/target/cli
+          chmod a+x deploy.azcli
+          ./deploy.azcli -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} -l ${{ env.location }} -t ${{ env.pullSecret }}
+      - name: Verify the deployment
+        run: |
+          outputs=$(az deployment group show -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} --query 'properties.outputs')
+          appEndpoint=$(echo $outputs | jq -r '.appEndpoint.value')
+          echo "appEndpoint: ${appEndpoint}"
+          if [[ $deployApplication == "true" ]]; then
+            if [[ -z "$appEndpoint" ]]; then
+              echo "Invalid value of appEndpoint: ${appEndpoint}"
+              exit 1
+            fi
+            curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appEndpoint
+            if [[ $? -ne 0 ]]; then
+              echo "Failed to access ${appEndpoint}."
+              exit 1
+            fi
+          elif [[ -n "$appEndpoint" ]]; then
+            echo "Invalid value of appEndpoint: ${appEndpoint}"
+            exit 1
+          fi
+      - name: Debugging with tmate if verification failed
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
+      - name: Delete all Azure resources
+        id: delete-resources-in-group
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) || (github.event_name == 'repository_dispatch' && github.event.client_payload.deleteAzureResources) }}
+        uses: azure/CLI@v1
+        with:
+          azcliversion: ${{ env.azCliVersion }}
+          inlineScript: |
+            az group delete -n ${{ env.testResourceGroup }} --yes
+      - name: Generate artifact file name and path
+        id: artifact_file
+        run: |
+          version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.repoName }}/pom.xml)
+          artifactName=${{ env.repoName }}-$version-arm-assembly
+          unzip ${{ env.repoName }}/target/$artifactName.zip -d ${{ env.repoName }}/target/$artifactName
+          echo "##[set-output name=artifactName;]${artifactName}"
+          echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
+      - name: Archive ${{ env.repoName }} template
+        uses: actions/upload-artifact@v1
+        if: success()
+        with:
+          name: ${{steps.artifact_file.outputs.artifactName}}
+          path: ${{steps.artifact_file.outputs.artifactPath}}
+  notification:
+    needs: integration-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Output inputs from workflow_dispatch
+        run: echo "${{ toJSON(github.event.inputs) }}"
+      - name: Output client_payload from repository_dispatch
+        run: echo "${{ toJSON(github.event.client_payload) }}"
+      - name: Send notification
+        if: ${{ env.msTeamsWebhook != 'NA' }}
+        run: |
+            workflowJobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ env.userName }}/${{ env.repoName }}/actions/runs/${{ github.run_id }}/jobs)
+            successIntegrationTestJob=$(echo $workflowJobs | jq '.jobs | map(select(.name=="integration-test" and .conclusion=="success")) | length')
+            if (($successIntegrationTestJob == 0));then
+                echo "Job integration-test failed, send notification to Teams"
+                curl ${{ env.msTeamsWebhook }} \
+                -H 'Content-Type: application/json' \
+                --data-binary @- << EOF
+                {
+                "@context":"http://schema.org/extensions",
+                "@type":"MessageCard",
+                "text":"Workflow integration-test of repo ${{ env.repoName }} failed, please take a look at: https://github.com/${{ env.userName }}/${{ env.repoName }}/actions/runs/${{ github.run_id }}"
+                }
+            EOF
+            else
+                echo "Job integration-test succeeded."
+            fi

--- a/.github/workflows/setup-credentials.sh
+++ b/.github/workflows/setup-credentials.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+################################################
+# This script is invoked by a human who:
+# - has done az login.
+# - can create repository secrets in the github repo from which this file was cloned.
+# - has the gh client >= 2.0.0 installed.
+#
+# This script initializes the repo from which this file was cloned
+# with the necessary secrets to run the workflows.
+# 
+# This script should be invoked in the root directory of the github repo that was cloned, e.g.:
+# ```
+# cd <path-to-local-clone-of-the-github-repo>
+# ./.github/workflows/setup-credentials.sh
+# ``` 
+#
+# Script design taken from https://github.com/microsoft/NubesGen.
+#
+################################################
+
+################################################
+# Set environment variables - the main variables you might want to configure.
+#
+# Three letters to disambiguate names
+DISAMBIG_PREFIX=
+# User name for preceding GitHub account
+USER_NAME=
+# Owner/reponame, e.g., <USER_NAME>/azure.liberty.aro
+OWNER_REPONAME=
+# Id of the uami, e.g., /subscriptions/<sub-id>/resourcegroups/<rg-name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<uami-name>.
+# The uami must have a Contributor role in the subscription and an Application administrator role in Azure AD.
+UAMI_ID=
+# The pull secret text that you obtained from the Red Hat OpenShift Cluster Manager website.
+# See https://learn.microsoft.com/en-us/azure/openshift/tutorial-create-cluster?WT.mc_id=Portal-fx#get-a-red-hat-pull-secret-optional to get pull secret text.
+PULL_SECRET=
+# Optional: Web hook for Microsoft Teams channel
+MSTEAMS_WEBHOOK=
+
+# End set environment variables
+################################################
+
+
+set -Eeuo pipefail
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  # script cleanup here
+}
+
+setup_colors() {
+  if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
+    NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
+  else
+    NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+  fi
+}
+
+msg() {
+  echo >&2 -e "${1-}"
+}
+
+setup_colors
+
+read -r -p "Enter a disambiguation prefix (try initials with a sequence number, such as ejb01): " DISAMBIG_PREFIX
+
+if [ "$DISAMBIG_PREFIX" == '' ] ; then
+    msg "${RED}You must enter a disambiguation prefix."
+    exit 1;
+fi
+
+DISAMBIG_PREFIX=${DISAMBIG_PREFIX}`date +%m%d`
+
+# get USER_NAME if not set at the beginning of this file
+if [ "$USER_NAME" == '' ] ; then
+    read -r -p "Enter user name of GitHub account: " USER_NAME
+fi
+
+# get OWNER_REPONAME if not set at the beginning of this file
+if [ "$OWNER_REPONAME" == '' ] ; then
+    read -r -p "Enter owner/reponame (blank for upsteam of current fork): " OWNER_REPONAME
+fi
+
+if [ -z "${OWNER_REPONAME}" ] ; then
+    GH_FLAGS=""
+else
+    GH_FLAGS="--repo ${OWNER_REPONAME}"
+fi
+
+# get UAMI_ID if not set at the beginning of this file
+if [ "$UAMI_ID" == '' ] ; then
+    read -r -p "Enter Id of the uami in the format '/subscriptions/<sub-id>/resourcegroups/<rg-name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<uami-name>' (The uami must have a Contributor role in the subscription and an Application administrator role in Azure AD): " UAMI_ID
+fi
+
+# get PULL_SECRET if not set at the beginning of this file
+if [ "$PULL_SECRET" == '' ] ; then
+    read -r -p "Enter the pull secret text that you obtained from the Red Hat OpenShift Cluster Manager website. (See https://learn.microsoft.com/en-us/azure/openshift/tutorial-create-cluster?WT.mc_id=Portal-fx#get-a-red-hat-pull-secret-optional to get pull secret text): " PULL_SECRET
+fi
+
+# Optional: get MSTEAMS_WEBHOOK if not set at the beginning of this file
+if [ "$MSTEAMS_WEBHOOK" == '' ] ; then
+    read -r -p "[Optional] Enter Web hook for Microsoft Teams channel, or press 'Enter' to ignore: " MSTEAMS_WEBHOOK
+fi
+
+if [ -z "${MSTEAMS_WEBHOOK}" ] ; then
+    MSTEAMS_WEBHOOK=NA
+fi
+
+SERVICE_PRINCIPAL_NAME=${DISAMBIG_PREFIX}sp
+
+# Check AZ CLI status
+msg "${GREEN}(1/4) Checking Azure CLI status...${NOFORMAT}"
+{
+  az > /dev/null
+} || {
+  msg "${RED}Azure CLI is not installed."
+  msg "${GREEN}Go to https://aka.ms/nubesgen-install-az-cli to install Azure CLI."
+  exit 1;
+}
+{
+  az account show > /dev/null
+} || {
+  msg "${RED}You are not authenticated with Azure CLI."
+  msg "${GREEN}Run \"az login\" to authenticate."
+  exit 1;
+}
+
+msg "${YELLOW}Azure CLI is installed and configured!"
+
+# Check GitHub CLI status
+msg "${GREEN}(2/4) Checking GitHub CLI status...${NOFORMAT}"
+USE_GITHUB_CLI=false
+{
+  gh auth status && USE_GITHUB_CLI=true && msg "${YELLOW}GitHub CLI is installed and configured!"
+} || {
+  msg "${YELLOW}Cannot use the GitHub CLI. ${GREEN}No worries! ${YELLOW}We'll set up the GitHub secrets manually."
+  USE_GITHUB_CLI=false
+}
+
+# Create service principal with Contributor role in the subscription
+msg "${GREEN}(3/4) Create service principal ${SERVICE_PRINCIPAL_NAME}"
+SUBSCRIPTION_ID=$(az account show --query id --output tsv --only-show-errors)
+SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --name ${SERVICE_PRINCIPAL_NAME} --role="Contributor" --scopes="/subscriptions/${SUBSCRIPTION_ID}" --sdk-auth --only-show-errors | base64 -w0)
+msg "${YELLOW}\"DISAMBIG_PREFIX\""
+msg "${GREEN}${DISAMBIG_PREFIX}"
+
+SP_ID=$(az ad sp list --display-name $SERVICE_PRINCIPAL_NAME --query [0].id -o tsv)
+az role assignment create --assignee ${SP_ID} --role "User Access Administrator"
+
+# Create GitHub action secrets
+AZURE_CREDENTIALS=$(echo $SERVICE_PRINCIPAL | base64 -d)
+
+msg "${GREEN}(4/4) Create secrets in GitHub"
+if $USE_GITHUB_CLI; then
+  {
+    msg "${GREEN}Using the GitHub CLI to set secrets.${NOFORMAT}"
+    gh ${GH_FLAGS} secret set AZURE_CREDENTIALS -b"${AZURE_CREDENTIALS}"
+    msg "${YELLOW}\"AZURE_CREDENTIALS\""
+    msg "${GREEN}${AZURE_CREDENTIALS}"
+    gh ${GH_FLAGS} secret set USER_NAME -b"${USER_NAME}"
+    gh ${GH_FLAGS} secret set UAMI_ID -b"${UAMI_ID}"
+    gh ${GH_FLAGS} secret set PULL_SECRET -b"${PULL_SECRET}"
+    gh ${GH_FLAGS} secret set MSTEAMS_WEBHOOK -b"${MSTEAMS_WEBHOOK}"
+    msg "${GREEN}Secrets configured"
+  } || {
+    USE_GITHUB_CLI=false
+  }
+fi
+if [ $USE_GITHUB_CLI == false ]; then
+  msg "${NOFORMAT}======================MANUAL SETUP======================================"
+  msg "${GREEN}Using your Web browser to set up secrets..."
+  msg "${NOFORMAT}Go to the GitHub repository you want to configure."
+  msg "${NOFORMAT}In the \"settings\", go to the \"secrets\" tab and the following secrets:"
+  msg "(in ${YELLOW}yellow the secret name and${NOFORMAT} in ${GREEN}green the secret value)"
+  msg "${YELLOW}\"AZURE_CREDENTIALS\""
+  msg "${GREEN}${AZURE_CREDENTIALS}"
+  msg "${YELLOW}\"USER_NAME\""
+  msg "${GREEN}${USER_NAME}"
+  msg "${YELLOW}\"UAMI_ID\""
+  msg "${GREEN}${UAMI_ID}"
+  msg "${YELLOW}\"PULL_SECRET\""
+  msg "${GREEN}${PULL_SECRET}"
+  msg "${YELLOW}\"MSTEAMS_WEBHOOK\""
+  msg "${GREEN}${MSTEAMS_WEBHOOK}"
+  msg "${NOFORMAT}========================================================================"
+fi

--- a/.github/workflows/setup-credentials.sh
+++ b/.github/workflows/setup-credentials.sh
@@ -30,9 +30,10 @@ OWNER_REPONAME=
 # Id of the uami, e.g., /subscriptions/<sub-id>/resourcegroups/<rg-name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<uami-name>.
 # The uami must have a Contributor role in the subscription and an Application administrator role in Azure AD.
 UAMI_ID=
-# The pull secret text that you obtained from the Red Hat OpenShift Cluster Manager website.
-# See https://learn.microsoft.com/en-us/azure/openshift/tutorial-create-cluster?WT.mc_id=Portal-fx#get-a-red-hat-pull-secret-optional to get pull secret text.
-PULL_SECRET=
+# The base64 encoded pull secret text.
+# See https://learn.microsoft.com/en-us/azure/openshift/tutorial-create-cluster?WT.mc_id=Portal-fx#get-a-red-hat-pull-secret-optional to obtain the pull secret from the Red Hat OpenShift Cluster Manager website.
+# Run "echo '<pull-secret-text>' | base64 -w0" to encode the pull secret.
+PULL_SECRET_ENCODED=
 # Optional: Web hook for Microsoft Teams channel
 MSTEAMS_WEBHOOK=
 
@@ -92,9 +93,9 @@ if [ "$UAMI_ID" == '' ] ; then
     read -r -p "Enter Id of the uami in the format '/subscriptions/<sub-id>/resourcegroups/<rg-name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<uami-name>' (The uami must have a Contributor role in the subscription and an Application administrator role in Azure AD): " UAMI_ID
 fi
 
-# get PULL_SECRET if not set at the beginning of this file
-if [ "$PULL_SECRET" == '' ] ; then
-    read -r -p "Enter the pull secret text that you obtained from the Red Hat OpenShift Cluster Manager website. (See https://learn.microsoft.com/en-us/azure/openshift/tutorial-create-cluster?WT.mc_id=Portal-fx#get-a-red-hat-pull-secret-optional to get pull secret text): " PULL_SECRET
+# get PULL_SECRET_ENCODED if not set at the beginning of this file
+if [ "$PULL_SECRET_ENCODED" == '' ] ; then
+    read -r -p "Enter the base64 encoded pull secret text (See https://learn.microsoft.com/en-us/azure/openshift/tutorial-create-cluster?WT.mc_id=Portal-fx#get-a-red-hat-pull-secret-optional to obtain the pull secret from the Red Hat OpenShift Cluster Manager website. Then run \"echo '<pull-secret-text>' | base64 -w0\" to encode the pull secret): " PULL_SECRET_ENCODED
 fi
 
 # Optional: get MSTEAMS_WEBHOOK if not set at the beginning of this file
@@ -159,7 +160,7 @@ if $USE_GITHUB_CLI; then
     msg "${GREEN}${AZURE_CREDENTIALS}"
     gh ${GH_FLAGS} secret set USER_NAME -b"${USER_NAME}"
     gh ${GH_FLAGS} secret set UAMI_ID -b"${UAMI_ID}"
-    gh ${GH_FLAGS} secret set PULL_SECRET -b"${PULL_SECRET}"
+    gh ${GH_FLAGS} secret set PULL_SECRET_ENCODED -b"${PULL_SECRET_ENCODED}"
     gh ${GH_FLAGS} secret set MSTEAMS_WEBHOOK -b"${MSTEAMS_WEBHOOK}"
     msg "${GREEN}Secrets configured"
   } || {
@@ -178,8 +179,8 @@ if [ $USE_GITHUB_CLI == false ]; then
   msg "${GREEN}${USER_NAME}"
   msg "${YELLOW}\"UAMI_ID\""
   msg "${GREEN}${UAMI_ID}"
-  msg "${YELLOW}\"PULL_SECRET\""
-  msg "${GREEN}${PULL_SECRET}"
+  msg "${YELLOW}\"PULL_SECRET_ENCODED\""
+  msg "${GREEN}${PULL_SECRET_ENCODED}"
   msg "${YELLOW}\"MSTEAMS_WEBHOOK\""
   msg "${GREEN}${MSTEAMS_WEBHOOK}"
   msg "${NOFORMAT}========================================================================"

--- a/.github/workflows/tear-down-credentials.sh
+++ b/.github/workflows/tear-down-credentials.sh
@@ -75,7 +75,7 @@ if $USE_GITHUB_CLI; then
     gh ${GH_FLAGS} secret remove AZURE_CREDENTIALS
     gh ${GH_FLAGS} secret remove USER_NAME
     gh ${GH_FLAGS} secret remove UAMI_ID
-    gh ${GH_FLAGS} secret remove PULL_SECRET
+    gh ${GH_FLAGS} secret remove PULL_SECRET_ENCODED
     gh ${GH_FLAGS} secret remove MSTEAMS_WEBHOOK
     msg "${GREEN}Secrets removed"
   } || {
@@ -91,7 +91,7 @@ if [ $USE_GITHUB_CLI == false ]; then
   msg "${YELLOW}\"AZURE_CREDENTIALS\""
   msg "${YELLOW}\"USER_NAME\""
   msg "${YELLOW}\"UAMI_ID\""
-  msg "${YELLOW}\"PULL_SECRET\""
+  msg "${YELLOW}\"PULL_SECRET_ENCODED\""
   msg "${YELLOW}\"MSTEAMS_WEBHOOK\""
   msg "${NOFORMAT}========================================================================"
 fi

--- a/.github/workflows/tear-down-credentials.sh
+++ b/.github/workflows/tear-down-credentials.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+################################################
+# This script is invoked by a human who:
+# - has invoked the setup-credentials.sh script
+#
+# This script removes the secrets created in setup-credentials.sh.
+#
+# This script should be invoked in the root directory of the github repo that was cloned, e.g.:
+# ```
+# cd <path-to-local-clone-of-the-github-repo>
+# ./.github/workflows/tear-down-credentials.sh
+# ``` 
+#
+# Script design taken from https://github.com/microsoft/NubesGen.
+#
+################################################
+
+
+set -Eeuo pipefail
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  # script cleanup here
+}
+
+setup_colors() {
+  if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
+    NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
+  else
+    NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+  fi
+}
+
+msg() {
+  echo >&2 -e "${1-}"
+}
+
+setup_colors
+
+read -r -p "Enter disambiguation prefix: " DISAMBIG_PREFIX
+read -r -p "Enter owner/reponame (blank for upsteam of current fork): " OWNER_REPONAME
+
+if [ -z "${OWNER_REPONAME}" ] ; then
+    GH_FLAGS=""
+else
+    GH_FLAGS="--repo ${OWNER_REPONAME}"
+fi
+
+SERVICE_PRINCIPAL_NAME=${DISAMBIG_PREFIX}sp
+
+# Delete app registration and its service principal together
+msg "${GREEN}(1/3) Delete service principal ${SERVICE_PRINCIPAL_NAME}"
+APP_ID_ARRAY=$(az ad app list --display-name ${SERVICE_PRINCIPAL_NAME} --query "[].appId") || true
+# Remove whitespace
+APP_ID_ARRAY=$(echo ${APP_ID_ARRAY} | xargs) || true
+APP_ID_ARRAY=${APP_ID_ARRAY//[/}
+APP_ID=${APP_ID_ARRAY//]/}
+az ad app delete --id ${APP_ID} || true
+
+# Check GitHub CLI status
+msg "${GREEN}(2/3) Checking GitHub CLI status...${NOFORMAT}"
+USE_GITHUB_CLI=false
+{
+  gh auth status && USE_GITHUB_CLI=true && msg "${YELLOW}GitHub CLI is installed and configured!"
+} || {
+  msg "${YELLOW}Cannot use the GitHub CLI. ${GREEN}No worries! ${YELLOW}We'll remove the GitHub secrets manually."
+  USE_GITHUB_CLI=false
+}
+
+msg "${GREEN}(3/3) Removing secrets...${NOFORMAT}"
+if $USE_GITHUB_CLI; then
+  {
+    msg "${GREEN}Using the GitHub CLI to remove secrets.${NOFORMAT}"
+    gh ${GH_FLAGS} secret remove AZURE_CREDENTIALS
+    gh ${GH_FLAGS} secret remove USER_NAME
+    gh ${GH_FLAGS} secret remove UAMI_ID
+    gh ${GH_FLAGS} secret remove PULL_SECRET
+    gh ${GH_FLAGS} secret remove MSTEAMS_WEBHOOK
+    msg "${GREEN}Secrets removed"
+  } || {
+    USE_GITHUB_CLI=false
+  }
+fi
+if [ $USE_GITHUB_CLI == false ]; then
+  msg "${NOFORMAT}======================MANUAL REMOVAL======================================"
+  msg "${GREEN}Using your Web browser to remove secrets..."
+  msg "${NOFORMAT}Go to the GitHub repository you want to configure."
+  msg "${NOFORMAT}In the \"settings\", go to the \"secrets\" tab and remove the following secrets:"
+  msg "(in ${YELLOW}yellow the secret name)"
+  msg "${YELLOW}\"AZURE_CREDENTIALS\""
+  msg "${YELLOW}\"USER_NAME\""
+  msg "${YELLOW}\"UAMI_ID\""
+  msg "${YELLOW}\"PULL_SECRET\""
+  msg "${YELLOW}\"MSTEAMS_WEBHOOK\""
+  msg "${NOFORMAT}========================================================================"
+fi

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 1. Using `deploy.azcli` to deploy
 
    ```bash
-   ./deploy.azcli -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l eastus -p <pull-secret-path> -c <aadClientId> -s <aadClientSecret> -a <aadObjectId> -r <rpObjectId>
+   ./deploy.azcli -n <deploymentName> -g <resourceGroupName> -l eastus -p <pull-secret-path> -c <aadClientId> -s <aadClientSecret> -a <aadObjectId> -r <rpObjectId>
    ```
 
 ## After deployment

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@
 1. Build the project by replacing all placeholder `${<place_holder>}` with valid values
    1. Create a new ARO 4 cluster:
       ```bash
-      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DidentityId=<user-assigned-managed-identity-id> -DcreateCluster=true -DuamiHasAppAdminRole=<true|false> -DprojMgrUsername=<project-mgr-username> -DprojMgrPassword=<project-mgr-username> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<app-replicas> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
+      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DidentityId=<user-assigned-managed-identity-id> -DcreateCluster=true -DuamiHasAppAdminRole=<true|false> -DdeployWLO=<true|false> -Dedition=<edition> -DproductEntitlementSource=<productEntitlementSource> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<app-replicas> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
       ```
 
    1. Use an existing ARO 4 cluster:
       ```bash
-      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DidentityId=<user-assigned-managed-identity-id> -DcreateCluster=false -DclusterName=<cluste-name> -DclusterRGName=<cluster-resource-group-name> -DprojMgrUsername=<project-mgr-username> -DprojMgrPassword=<project-mgr-username> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<app-replicas> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
+      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DidentityId=<user-assigned-managed-identity-id> -DcreateCluster=false -DclusterName=<cluste-name> -DclusterRGName=<cluster-resource-group-name> -DdeployWLO=<true|false> -Dedition=<edition> -DproductEntitlementSource=<productEntitlementSource> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<app-replicas> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
       ```
 
 1. Change to `./target/cli` directory

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.38</version>
+    <version>1.0.39</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -253,13 +253,33 @@
                         }
                     },
                     {
+                        "name": "deployApplication",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Deploy an application?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' to deploy an application, or select 'No' if you prefer to manually deploy application later.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": "true"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "false"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
                         "name": "licenseInfo",
                         "type": "Microsoft.Common.InfoBox",
                         "options": {
                             "icon": "Info",
                             "text": "I accept the terms on the license agreement corresponding to the version of IBM Program in the application container by setting this value to true. See <a href='https://ibm.biz/was-license' target='_blank'>https://ibm.biz/was-license</a> for the license agreement applicable to this IBM Program. You must accept the license for the installation to work."
                         },
-                        "visible": "[bool(steps('Application').deployWLO)]"
+                        "visible": "[and(bool(steps('Application').deployWLO), bool(steps('Application').deployApplication))]"
                     },
                     {
                         "name": "acceptIBMLicenseAgreement",
@@ -270,7 +290,7 @@
                             "required": true,
                             "validationMessage": "The deployment will not proceed unless you accept the License Agreement."
                         },
-                        "visible": "[bool(steps('Application').deployWLO)]"
+                        "visible": "[and(bool(steps('Application').deployWLO), bool(steps('Application').deployApplication))]"
                     },
                     {
                         "name": "edition",
@@ -295,7 +315,7 @@
                             ],
                             "required": true
                         },
-                        "visible": "[bool(steps('Application').deployWLO)]"
+                        "visible": "[and(bool(steps('Application').deployWLO), bool(steps('Application').deployApplication))]"
                     },
                     {
                         "name": "productEntitlementSource",
@@ -324,27 +344,7 @@
                             ],
                             "required": true
                         },
-                        "visible": "[bool(steps('Application').deployWLO)]"
-                    },
-                    {
-                        "name": "deployApplication",
-                        "type": "Microsoft.Common.OptionsGroup",
-                        "label": "Deploy an application?",
-                        "defaultValue": "No",
-                        "toolTip": "Select 'Yes' to deploy an application, or select 'No' if you prefer to manually deploy application later.",
-                        "constraints": {
-                            "allowedValues": [
-                                {
-                                    "label": "Yes",
-                                    "value": "true"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "false"
-                                }
-                            ],
-                            "required": true
-                        }
+                        "visible": "[and(bool(steps('Application').deployWLO), bool(steps('Application').deployApplication))]"
                     },
                     {
                         "name": "appImageInfo",

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -225,13 +225,107 @@
             },
             {
                 "name": "Application",
-                "label": "Configure application",
+                "label": "Operator and application",
                 "subLabel": {
-                    "preValidation": "Provide required info for application",
+                    "preValidation": "Provide required info for Operator and application",
                     "postValidation": "Done"
                 },
-                "bladeTitle": "Configure application",
+                "bladeTitle": "Operator and application",
                 "elements": [
+                    {
+                        "name": "deployWLO",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "IBM supported?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' if your deployments are to be supported under existing WebSphere entitlements (this includes supported deployments of Open Liberty). Select 'Yes' if you are deploying WebSphere Liberty under the Trial license terms. Select 'No' if you are deploying Open Liberty unsupported.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": "true"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "false"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "licenseInfo",
+                        "type": "Microsoft.Common.InfoBox",
+                        "options": {
+                            "icon": "Info",
+                            "text": "I accept the terms on the license agreement corresponding to the version of IBM Program in the application container by setting this value to true. See <a href='https://ibm.biz/was-license' target='_blank'>https://ibm.biz/was-license</a> for the license agreement applicable to this IBM Program. You must accept the license for the installation to work."
+                        },
+                        "visible": "[bool(steps('Application').deployWLO)]"
+                    },
+                    {
+                        "name": "acceptIBMLicenseAgreement",
+                        "type": "Microsoft.Common.CheckBox",
+                        "label": "Accept license",
+                        "toolTip": "Select to accept the License Agreement.",
+                        "constraints": {
+                            "required": true,
+                            "validationMessage": "The deployment will not proceed unless you accept the License Agreement."
+                        },
+                        "visible": "[bool(steps('Application').deployWLO)]"
+                    },
+                    {
+                        "name": "edition",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "defaultValue": "IBM WebSphere Application Server",
+                        "label": "Edition",
+                        "toolTip": "Product edition",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "IBM WebSphere Application Server",
+                                    "value": "IBM WebSphere Application Server"
+                                },
+                                {
+                                    "label": "IBM WebSphere Application Server Liberty Core",
+                                    "value": "IBM WebSphere Application Server Liberty Core"
+                                },
+                                {
+                                    "label": "IBM WebSphere Application Server Network Deployment",
+                                    "value": "IBM WebSphere Application Server Network Deployment"
+                                }
+                            ],
+                            "required": true
+                        },
+                        "visible": "[bool(steps('Application').deployWLO)]"
+                    },
+                    {
+                        "name": "productEntitlementSource",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "defaultValue": "Standalone",
+                        "label": "Product entitlement source",
+                        "toolTip": "Entitlement source for the product",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Standalone",
+                                    "value": "Standalone"
+                                },
+                                {
+                                    "label": "IBM WebSphere Hybrid Edition",
+                                    "value": "IBM WebSphere Hybrid Edition"
+                                },
+                                {
+                                    "label": "IBM Cloud Pak for Applications",
+                                    "value": "IBM Cloud Pak for Applications"
+                                },
+                                {
+                                    "label": "IBM WebSphere Application Server Family Edition",
+                                    "value": "IBM WebSphere Application Server Family Edition"
+                                }
+                            ],
+                            "required": true
+                        },
+                        "visible": "[bool(steps('Application').deployWLO)]"
+                    },
                     {
                         "name": "deployApplication",
                         "type": "Microsoft.Common.OptionsGroup",
@@ -337,6 +431,9 @@
             "rpObjectId": "[steps('Cluster').createClusterInfo.rpObjectId]",
             "clusterName": "[last(split(steps('Cluster').clusterInfo.clusterSelector.id, '/'))]",
             "clusterRGName": "[last(take(split(steps('Cluster').clusterInfo.clusterSelector.id, '/'), 5))]",
+            "deployWLO": "[bool(steps('Application').deployWLO)]",
+            "edition": "[steps('Application').edition]",
+            "productEntitlementSource": "[steps('Application').productEntitlementSource]",
             "deployApplication": "[bool(steps('Application').deployApplication)]",
             "appImagePath": "[if(equals(steps('Application').appImageInfo.appImageOption, '2'), 'icr.io/appcafe/open-liberty/samples/getting-started', if(equals(steps('Application').appImageInfo.appImageOption, '3'), 'docker.io/ibmcom/websphere-liberty-sample:1.0.0', steps('Application').appImageInfo.appImagePath))]",
             "appReplicas": "[int(steps('Application').appLoadBalancingInfo.appReplicas)]"

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -499,9 +499,19 @@
             "value": "[reference(variables('name_deploymentScriptName')).outputs.appDeploymentYaml]",
             "type": "string"
         },
+        "appDeploymentYaml": {
+            "condition": "[parameters('deployApplication')]",
+            "value": "[format('echo \"{0}\" | base64 -d', reference(variables('name_deploymentScriptName')).outputs.appDeploymentYaml)]",
+            "type": "string"
+        },
         "appDeploymentTemplateYamlEncoded (Use `echo \"copied-value\" | base64 -d` to decode the text)": {
             "condition": "[not(parameters('deployApplication'))]",
             "value": "[reference(variables('name_deploymentScriptName')).outputs.appDeploymentYaml]",
+            "type": "string"
+        },
+        "appDeploymentTemplateYaml": {
+            "condition": "[not(parameters('deployApplication'))]",
+            "value": "[format('echo \"{0}\" | base64 -d', reference(variables('name_deploymentScriptName')).outputs.appDeploymentYaml)]",
             "type": "string"
         },
         "cmdToUpdateOrCreateApplication (Please execute command in `cmdToLoginWithProjManager` before executing this one)": {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -374,6 +374,7 @@
                 "supportingScriptUris":[
                     "[uri(variables('const_scriptLocation'), concat('open-liberty-operator-subscription.yaml', parameters('_artifactsLocationSasToken')))]",
                     "[uri(variables('const_scriptLocation'), concat('open-liberty-application.yaml.template', parameters('_artifactsLocationSasToken')))]",
+                    "[uri(variables('const_scriptLocation'), concat('catalog-source.yaml', parameters('_artifactsLocationSasToken')))]",
                     "[uri(variables('const_scriptLocation'), concat('websphere-liberty-operator-subscription.yaml', parameters('_artifactsLocationSasToken')))]",
                     "[uri(variables('const_scriptLocation'), concat('websphere-liberty-application.yaml.template', parameters('_artifactsLocationSasToken')))]"
                 ],

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -103,7 +103,7 @@
             "type": "bool",
             "defaultValue": false,
             "metadata": {
-                "description": "Flag indicating whether to deploy WebSphere Liberty operator."
+                "description": "Flag indicating whether to deploy WebSphere Liberty Operator."
             }
         },
         "edition": {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -99,6 +99,38 @@
                 "description": "Worker Node VM Type"
             }
         },
+        "deployWLO": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Flag indicating whether to deploy WebSphere Liberty operator."
+            }
+        },
+        "edition": {
+            "type": "string",
+            "defaultValue": "IBM WebSphere Application Server",
+            "metadata": {
+                "description": "Product edition"
+            },
+            "allowedValues": [
+                "IBM WebSphere Application Server",
+                "IBM WebSphere Application Server Liberty Core",
+                "IBM WebSphere Application Server Network Deployment"
+            ]
+        },
+        "productEntitlementSource": {
+            "type": "string",
+            "defaultValue": "Standalone",
+            "metadata": {
+                "description": "Entitlement source for the product"
+            },
+            "allowedValues": [
+                "Standalone",
+                "IBM WebSphere Hybrid Edition",
+                "IBM Cloud Pak for Applications",
+                "IBM WebSphere Application Server Family Edition"
+            ]
+        },  
         "deployApplication": {
             "defaultValue": false,
             "type": "bool",
@@ -142,6 +174,7 @@
         "const_cmdToGetKubeadminPassword": "[concat(variables('const_cmdToGetKubeadminCredentials'), ' --query kubeadminPassword -o tsv')]",
         "const_cmdToGetKubeadminUsername": "[concat(variables('const_cmdToGetKubeadminCredentials'), ' --query kubeadminUsername -o tsv')]",
         "const_contribRole": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+        "const_metric": "[if(or(equals(parameters('productEntitlementSource'), 'Standalone'), equals(parameters('productEntitlementSource'), 'IBM WebSphere Application Server Family Edition')), 'Processor Value Unit (PVU)', 'Virtual Processor Core (VPC)')]",
         "const_scriptLocation": "[uri(parameters('_artifactsLocation'), 'scripts/')]",
         "const_suffix": "[take(replace(parameters('guidValue'), '-', ''), 6)]",
         "name_clusterName": "[if(parameters('createCluster'), concat('cluster', variables('const_suffix')), parameters('clusterName'))]",
@@ -340,7 +373,27 @@
                 "primaryScriptUri": "[uri(variables('const_scriptLocation'), concat('install.sh', parameters('_artifactsLocationSasToken')))]",
                 "supportingScriptUris":[
                     "[uri(variables('const_scriptLocation'), concat('open-liberty-operator-subscription.yaml', parameters('_artifactsLocationSasToken')))]",
-                    "[uri(variables('const_scriptLocation'), concat('open-liberty-application.yaml.template', parameters('_artifactsLocationSasToken')))]"
+                    "[uri(variables('const_scriptLocation'), concat('open-liberty-application.yaml.template', parameters('_artifactsLocationSasToken')))]",
+                    "[uri(variables('const_scriptLocation'), concat('websphere-liberty-operator-subscription.yaml', parameters('_artifactsLocationSasToken')))]",
+                    "[uri(variables('const_scriptLocation'), concat('websphere-liberty-application.yaml.template', parameters('_artifactsLocationSasToken')))]"
+                ],
+                "environmentVariables": [
+                    {
+                        "name": "DEPLOY_WLO",
+                        "value": "[parameters('deployWLO')]"
+                    },
+                    {
+                        "name": "WLA_EDITION",
+                        "value": "[parameters('edition')]"
+                    },
+                    {
+                        "name": "WLA_PRODUCT_ENTITLEMENT_SOURCE",
+                        "value": "[parameters('productEntitlementSource')]"
+                    },
+                    {
+                        "name": "WLA_METRIC",
+                        "value": "[variables('const_metric')]"
+                    }
                 ],
                 "cleanupPreference": "OnSuccess",
                 "retentionInterval": "P1D"

--- a/src/main/arm/parameters.json
+++ b/src/main/arm/parameters.json
@@ -22,6 +22,15 @@
         "clusterRGName": {
             "value": "${clusterRGName}"
         },
+        "deployWLO": {
+            "value": "${deployWLO}"
+        },
+        "edition": {
+            "value": "${edition}"
+        },
+        "productEntitlementSource": {
+            "value": "${productEntitlementSource}"
+        },
         "deployApplication": {
             "value": "${deployApplication}"
         },

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -21,15 +21,15 @@ IFS=$'\n\t'
 # -o: prevents errors in a pipeline from being masked
 # IFS new value is less likely to cause confusing bugs when looping arrays or arguments (e.g. $@)
 
-usage() { echo "Usage: $0 -n <deploymentName> -p <pullSecretFile> -c <aadClientId> -s <aadClientSecret> -a <aadObjectId> -r <rpObjectId> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
+usage() { echo "Usage: $0 -n <deploymentName> -p <pullSecretFile> -t <pullSecret> -c <aadClientId> -s <aadClientSecret> -a <aadObjectId> -r <rpObjectId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
 
 declare deploymentName=""
 declare pullSecretFile=""
+declare pullSecret=""
 declare aadClientId=""
 declare aadClientSecret=""
 declare aadObjectId=""
 declare rpObjectId=""
-declare subscriptionId=""
 declare resourceGroupName=""
 declare resourceGroupLocation=""
 
@@ -42,6 +42,9 @@ while getopts ":n:p:i:g:l:c:s:a:r:" arg; do
 		p)
 			pullSecretFile=${OPTARG}
 			;;
+		t)
+			pullSecret=${OPTARG}
+			;;
 		c)
 			aadClientId=${OPTARG}
 			;;
@@ -53,9 +56,6 @@ while getopts ":n:p:i:g:l:c:s:a:r:" arg; do
 			;;
 		r)
 			rpObjectId=${OPTARG}
-			;;
-		i)
-			subscriptionId=${OPTARG}
 			;;
 		g)
 			resourceGroupName=${OPTARG}
@@ -71,13 +71,6 @@ shift $((OPTIND-1))
 if [[ -z "$deploymentName" ]]; then
 	echo "Enter a name for this deployment:"
 	read deploymentName
-fi
-
-if [[ -z "$subscriptionId" ]]; then
-	echo "Your subscription ID can be looked up with the CLI using: az account show --out json "
-	echo "Enter your subscription ID:"
-	read subscriptionId
-	[[ "${subscriptionId:?}" ]]
 fi
 
 if [[ -z "$resourceGroupName" ]]; then
@@ -96,8 +89,8 @@ if [[ -z "$resourceGroupLocation" ]]; then
 	read resourceGroupLocation
 fi
 
-if [ -z "$deploymentName" ] || [ -z "$subscriptionId" ] || [ -z "$resourceGroupName" ]; then
-	echo "Either one of deploymentName, subscriptionId and resourceGroupName is empty"
+if [ -z "$deploymentName" ] || [ -z "$resourceGroupName" ]; then
+	echo "Either one of deploymentName and resourceGroupName is empty"
 	usage
 fi
 
@@ -124,9 +117,6 @@ if [ $? != 0 ]; then
 	az login
 fi
 
-# set the default subscription id
-az account set --subscription $subscriptionId
-
 set +e
 
 # Check for existing RG
@@ -144,10 +134,11 @@ else
 fi
 resourceGroupLocation=$( az group show --name $resourceGroupName | jq -r '.location' )
 
-# Read pull secret
+# Read pull secret file
 if [ -f "$pullSecretFile" ]; then
 	pullSecret=$( cat "$pullSecretFile" | jq -c '.' )
-else
+# Set as empty if pull secret string is not provided either
+elif [ -z "$pullSecret" ]; then
 	pullSecret="{}"
 fi
 

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -21,11 +21,11 @@ IFS=$'\n\t'
 # -o: prevents errors in a pipeline from being masked
 # IFS new value is less likely to cause confusing bugs when looping arrays or arguments (e.g. $@)
 
-usage() { echo "Usage: $0 -n <deploymentName> -p <pullSecretFile> -t <pullSecret> -c <aadClientId> -s <aadClientSecret> -a <aadObjectId> -r <rpObjectId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
+usage() { echo "Usage: $0 -n <deploymentName> -p <pullSecretFile> -t <pullSecretEncoded> -c <aadClientId> -s <aadClientSecret> -a <aadObjectId> -r <rpObjectId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
 
 declare deploymentName=""
 declare pullSecretFile=""
-declare pullSecret=""
+declare pullSecretEncoded=""
 declare aadClientId=""
 declare aadClientSecret=""
 declare aadObjectId=""
@@ -34,7 +34,7 @@ declare resourceGroupName=""
 declare resourceGroupLocation=""
 
 # Initialize parameters specified from command line
-while getopts ":n:p:i:g:l:c:s:a:r:" arg; do
+while getopts ":n:p:t:i:g:l:c:s:a:r:" arg; do
 	case "${arg}" in
 		n)
 			deploymentName=${OPTARG}
@@ -43,7 +43,7 @@ while getopts ":n:p:i:g:l:c:s:a:r:" arg; do
 			pullSecretFile=${OPTARG}
 			;;
 		t)
-			pullSecret=${OPTARG}
+			pullSecretEncoded=${OPTARG}
 			;;
 		c)
 			aadClientId=${OPTARG}
@@ -138,7 +138,9 @@ resourceGroupLocation=$( az group show --name $resourceGroupName | jq -r '.locat
 if [ -f "$pullSecretFile" ]; then
 	pullSecret=$( cat "$pullSecretFile" | jq -c '.' )
 # Set as empty if pull secret string is not provided either
-elif [ -z "$pullSecret" ]; then
+elif [ -n "$pullSecretEncoded" ]; then
+	pullSecret=$( echo $pullSecretEncoded | base64 -d | jq -c '.' )
+else
 	pullSecret="{}"
 fi
 

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -155,6 +155,8 @@ fi
 parametersJson=$( cat $parametersFilePath | jq '.parameters' )
 createCluster=$( echo $parametersJson | jq '.createCluster.value' | sed 's/"//g' )
 parametersJson=$( echo $parametersJson | jq --argjson createCluster "$createCluster" '.createCluster.value = $createCluster' )
+deployWLO=$( echo $parametersJson | jq '.deployWLO.value' | sed 's/"//g' )
+parametersJson=$( echo $parametersJson | jq --argjson deployWLO "$deployWLO" '.deployWLO.value = $deployWLO' )
 deployApplication=$( echo $parametersJson | jq '.deployApplication.value' | sed 's/"//g' )
 parametersJson=$( echo $parametersJson | jq --argjson deployApp "$deployApplication" '.deployApplication.value = $deployApp' )
 appReplicas=$( echo $parametersJson | jq '.appReplicas.value' | sed 's/"//g' )

--- a/src/main/resources/README.md
+++ b/src/main/resources/README.md
@@ -47,7 +47,7 @@
 - Summary
   - Provisions IBM WebSphere Liberty on Azure Red Hat OpenShift
 - Long Summary
-  - Provisions IBM WebSphere Liberty on Azure Red Hat OpenShift with built in container registry, WAR/EAR deployment, and the Open Liberty Kubernetes operator.
+  - Provisions IBM WebSphere Liberty on Azure Red Hat OpenShift with built in container registry, WAR/EAR deployment, and the Open/WebSphere Liberty Kubernetes Operator.
 - Description
   - IBM WebSphere Liberty provides a flexible, secure server runtime environment for large-scale and mission critical application deployments. This offer provisions an IBM WebSphere Liberty environment on Azure Red Hat OpenShift.
 
@@ -154,7 +154,7 @@
 - Summary
   - Provisions IBM WebSphere Liberty on Azure Red Hat OpenShift
 - Description
-  - Provisions IBM WebSphere Liberty on Azure Red Hat OpenShift with built in container registry, WAR/EAR deployment, and the Open Liberty Kubernetes operator.
+  - Provisions IBM WebSphere Liberty on Azure Red Hat OpenShift with built in container registry, WAR/EAR deployment, and the Open/WebSphere Liberty Kubernetes Operator.
 
 ### Availability
 

--- a/src/main/scripts/catalog-source.yaml
+++ b/src/main/scripts/catalog-source.yaml
@@ -1,0 +1,30 @@
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Reference https://www.ibm.com/docs/en/cloud-paks/1.0?topic=clusters-adding-operator-catalog
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+  annotations:
+    olm.catalogImageTemplate: "icr.io/cpopen/ibm-operator-catalog:v{kube_major_version}.{kube_minor_version}"
+spec:
+  displayName: IBM Operator Catalog
+  publisher: IBM
+  sourceType: grpc
+  image: docker.io/ibmcom/ibm-operator-catalog:latest
+  updateStrategy:
+    registryPoll:
+      interval: 45m

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -282,7 +282,7 @@ if [ "$DEPLOY_WLO" = False ]; then
     wait_subscription_created open-liberty-certified openshift-operators open-liberty-operator-subscription.yaml ${logFile}
 else
     # Add the IBM operator catalog
-    oc apply -f catalog-source.yaml
+    wait_resource_applied catalog-source.yaml $logFile
     # Install WebSphere Liberty Operator
     operatorDeploymentName=wlo-controller-manager
     wait_subscription_created ibm-websphere-liberty openshift-operators websphere-liberty-operator-subscription.yaml ${logFile}

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -281,8 +281,10 @@ if [ "$DEPLOY_WLO" = False ]; then
     operatorDeploymentName=olo-controller-manager
     wait_subscription_created open-liberty-certified openshift-operators open-liberty-operator-subscription.yaml ${logFile}
 else
+    # Add the IBM operator catalog
+    oc apply -f catalog-source.yaml
     # Install WebSphere Liberty Operator
-    operatorDeploymentName=websphere-liberty-controller-manager
+    operatorDeploymentName=wlo-controller-manager
     wait_subscription_created ibm-websphere-liberty openshift-operators websphere-liberty-operator-subscription.yaml ${logFile}
 fi
 if [[ $? -ne 0 ]]; then

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -42,7 +42,8 @@ wait_login_complete() {
 wait_subscription_created() {
     subscriptionName=$1
     namespaceName=$2
-    logFile=$3
+    deploymentYaml=$3
+    logFile=$4
 
     cnt=0
     oc get packagemanifests -n openshift-marketplace | grep -q ${subscriptionName}
@@ -60,7 +61,7 @@ wait_subscription_created() {
     done
 
     cnt=0
-    oc apply -f open-liberty-operator-subscription.yaml >> $logFile
+    oc apply -f ${deploymentYaml} >> $logFile
     while [ $? -ne 0 ]
     do
         if [ $cnt -eq $MAX_RETRIES ]; then
@@ -71,7 +72,7 @@ wait_subscription_created() {
 
         echo "Failed to create the operator subscription ${subscriptionName}, retry ${cnt} of ${MAX_RETRIES}..." >> $logFile
         sleep 5
-        oc apply -f open-liberty-operator-subscription.yaml >> $logFile
+        oc apply -f ${deploymentYaml} >> $logFile
     done
 
     cnt=0
@@ -274,15 +275,23 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-# Install Open Liberty Operator
-wait_subscription_created open-liberty-certified openshift-operators ${logFile}
+operatorDeploymentName=
+if [ "$DEPLOY_WLO" = False ]; then
+    # Install Open Liberty Operator
+    operatorDeploymentName=olo-controller-manager
+    wait_subscription_created open-liberty-certified openshift-operators open-liberty-operator-subscription.yaml ${logFile}
+else
+    # Install WebSphere Liberty Operator
+    operatorDeploymentName=websphere-liberty-controller-manager
+    wait_subscription_created ibm-websphere-liberty openshift-operators websphere-liberty-operator-subscription.yaml ${logFile}
+fi
 if [[ $? -ne 0 ]]; then
-  echo "Failed to install the Open Liberty Operator from the OperatorHub." >&2
+  echo "Failed to install the Open/WebSphere Liberty Operator from the OperatorHub." >&2
   exit 1
 fi
-wait_deployment_complete olo-controller-manager openshift-operators ${logFile}
+wait_deployment_complete ${operatorDeploymentName} openshift-operators ${logFile}
 if [[ $? -ne 0 ]]; then
-  echo "The Open Liberty Operator is not available." >&2
+  echo "The Open/WebSphere Liberty Operator is not available." >&2
   exit 1
 fi
 
@@ -294,6 +303,17 @@ if [[ $? -ne 0 ]]; then
 fi
 oc project $Project_Name
 
+# Choose right template
+appDeploymentTemplate=open-liberty-application.yaml.template
+if [ "$DEPLOY_WLO" = True ]; then
+    appDeploymentTemplate=websphere-liberty-application.yaml.template
+fi
+
+appDeploymentFile=liberty-application.yaml
+export WLA_Edition="${WLA_EDITION}"
+export WLA_Product_Entitlement_Source="${WLA_PRODUCT_ENTITLEMENT_SOURCE}"
+export WLA_Metric="${WLA_METRIC}"
+
 # Deploy application image if it's requested by the user
 if [ "$deployApplication" = True ]; then
     # Import container image to the built-in container registry of the OpenShift cluster
@@ -303,19 +323,19 @@ if [ "$deployApplication" = True ]; then
         exit 1
     fi
 
-    # Deploy open liberty application and output its base64 encoded deployment yaml file content
-    envsubst < "open-liberty-application.yaml.template" > "open-liberty-application.yaml"
-    appDeploymentYaml=$(cat open-liberty-application.yaml | base64)
-    wait_resource_applied open-liberty-application.yaml $logFile
+    # Deploy Open/WebSphere Liberty application and output its base64 encoded deployment yaml file content
+    envsubst "$appDeploymentTemplate" > "$appDeploymentFile"
+    appDeploymentYaml=$(cat $appDeploymentFile | base64)
+    wait_resource_applied $appDeploymentFile $logFile
     if [[ $? != 0 ]]; then
-        echo "Failed to create OpenLibertyApplication defined in open-liberty-application.yaml." >&2
+        echo "Failed to create Open/WebSphere Liberty application." >&2
         exit 1
     fi
 
     # Wait until the application deployment completes
     wait_deployment_complete ${Application_Name} ${Project_Name} ${logFile}
     if [[ $? != 0 ]]; then
-        echo "The OpenLibertyApplication ${Application_Name} is not available." >&2
+        echo "The Open/WebSphere Liberty application ${Application_Name} is not available." >&2
         exit 1
     fi
 
@@ -329,7 +349,13 @@ if [ "$deployApplication" = True ]; then
     echo "appEndpoint is ${appEndpoint}"
 else
     # Output base64 encoded deployment template yaml file content
-    appDeploymentYaml=$(cat open-liberty-application.yaml.template | sed -e "s/\${Project_Name}/${Project_Name}/g" -e "s/\${Application_Replicas}/${Application_Replicas}/g" | base64)
+    appDeploymentYaml=$(cat $appDeploymentTemplate \
+        | sed -e "s/\${Project_Name}/${Project_Name}/g" \
+        | sed -e "s/\${Application_Replicas}/${Application_Replicas}/g" \
+        | sed -e "s#\${WLA_Edition}#${WLA_Edition}#g" \
+        | sed -e "s#\${WLA_Product_Entitlement_Source}#${WLA_Product_Entitlement_Source}#g" \
+        | sed -e "s#\${WLA_Metric}#${WLA_Metric}#g" \
+        | base64)
 fi
 
 # Write outputs to deployment script output path

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -326,7 +326,7 @@ if [ "$deployApplication" = True ]; then
     fi
 
     # Deploy Open/WebSphere Liberty application and output its base64 encoded deployment yaml file content
-    envsubst "$appDeploymentTemplate" > "$appDeploymentFile"
+    envsubst < "$appDeploymentTemplate" > "$appDeploymentFile"
     appDeploymentYaml=$(cat $appDeploymentFile | base64)
     wait_resource_applied $appDeploymentFile $logFile
     if [[ $? != 0 ]]; then

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -1,3 +1,17 @@
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/src/main/scripts/websphere-liberty-application.yaml.template
+++ b/src/main/scripts/websphere-liberty-application.yaml.template
@@ -1,0 +1,30 @@
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: ${Application_Name}
+  namespace: ${Project_Name}
+spec:
+  license:
+    accept: true
+    edition: ${WLA_Edition}
+    metric: ${WLA_Metric}
+    productEntitlementSource: ${WLA_Product_Entitlement_Source}
+  replicas: ${Application_Replicas}
+  applicationImage: ${Application_Image}
+  pullPolicy: Always
+  manageTLS: false
+  expose: true

--- a/src/main/scripts/websphere-liberty-operator-subscription.yaml
+++ b/src/main/scripts/websphere-liberty-operator-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ibm-websphere-liberty
+  namespace: openshift-operators
+spec:
+  installPlanApproval: Automatic
+  name: ibm-websphere-liberty
+  source: ibm-operator-catalog
+  sourceNamespace: openshift-marketplace

--- a/src/main/scripts/websphere-liberty-operator-subscription.yaml
+++ b/src/main/scripts/websphere-liberty-operator-subscription.yaml
@@ -1,3 +1,17 @@
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:


### PR DESCRIPTION
## Description

The PR is to simplify the user experience by resolving the following issues:
* Resolve #74

## Change summary

* Update UI to support install WebSphere Liberty Operator
* Update ARM templates to support WLO
* Update scripts to support WLO
* Add two more templates for support `WebSphereLibertyApplication` CR
* Add `integration-test` pipeline which supports WLO

## Testing

Verified the following 4 test cases with `integration-test` pipeline (**Note**: For all cases enabled with **WLO**, **Edition** is `IBM WebSphere Application Server` and **Product entitlement source** is `Standalone`):
|WLO	|OLO	|Sample App|Pipeline run|
|-----|-----|----------|------------|
|X    |     |X         |[integration-test-13](https://github.com/majguo/azure.liberty.aro/actions/runs/3390259657)|
|X    |     |          |[integration-test-14](https://github.com/majguo/azure.liberty.aro/actions/runs/3390260548)|
|     |X    |X         |[integration-test-15](https://github.com/majguo/azure.liberty.aro/actions/runs/3390261619)|
|     |X    |          |[integration-test-16](https://github.com/majguo/azure.liberty.aro/actions/runs/3390262123)|

Verified the following 5 test cases using [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro):
|WLO	|OLO	|Sample App	|Edition                         				|Product entitlement source				  |
|-----|-----|-----------|-----------------------------------------------------|-------------------------------------------------|
|X    |     |X          |IBM WebSphere Application Server				|Standalone							  |
|X    |     |X          |IBM WebSphere Application Server Liberty Core		|IBM WebSphere Hybrid Edition				  |
|X    |     |X          |IBM WebSphere Application Server Network Deployment	|IBM Cloud Pak for Applications			  |
|X    |     |X          |IBM WebSphere Application Server Network Deployment	|IBM WebSphere Application Server Family Edition  |
|     |X    |X          |IBM WebSphere Application Server				|Standalone							  |

Feel free to do a live testing with [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro).

## UI changes review

Besides visiting [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro) for reviewing the renamed blade `Operator and application` (which comes from `Configure application`), reviewer can preview the UI changes using the **Create UI Definition Sandbox**:

- Open [Create UI Definition Sandbox](https://portal.azure.com/?feature.customPortal=false#blade/Microsoft_Azure_CreateUIDef/SandboxBlade) in a new tab of browser.
- Open UI source code [createUiDefinition.json](https://raw.githubusercontent.com/majguo/azure.liberty.aro/support-wlo/src/main/arm/createUiDefinition.json) in a new tab of the browser.
- Replace the content of work area in **Create UI Definition Sandbox** with the content of **UI source code `createUiDefinition.json`**.
- Click **Preview** at the left-bottom of **Create UI Definition Sandbox**.
- The UI changes in the renamed `Operator and application` blade include:
   - Add a new option **IBM supported? Yes/No**.
   - If selecting **Yes**, a checkbox **Accept license** and two more options **Edition** and **Product entitlement source** are displayed for user inputs. 

Also attached the screenshots for quick overview:

- **IBM supported: No (default)**
  ![image](https://user-images.githubusercontent.com/10357495/200326838-ab185081-9420-4c0f-bbaf-7eb670467a0f.png)
- **IBM supported: Yes**
  ![image](https://user-images.githubusercontent.com/10357495/200326955-df1619b5-1723-4765-9ef9-3095a8d62e7e.png)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>