### PR TITLE
Wait service principal available

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -101,9 +101,6 @@ jobs:
           clientSecret=$(echo $servicePrincipal | jq -r '.clientSecret')
           aadObjectId=$(az ad sp show --id ${clientId} --query id -o tsv)
           rpObjectId=$(az ad sp list --display-name "Azure Red Hat OpenShift RP" --query [0].id -o tsv)
-          # Wait 30s for service principal available after creation. 
-          # See https://github.com/WASdev/azure.liberty.aro/issues/59.
-          sleep 30
           cd ${{ env.repoName }}/target/cli
           chmod a+x deploy.azcli
           ./deploy.azcli -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} -l ${{ env.location }} -t ${{ env.pullSecretEncoded }} \

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.40</version>
+    <version>1.0.41</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -135,7 +135,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "An Azure Active Directory service principal is required for cluster creation. For more information on creating a service principal, consult the <a href='https://aka.ms/aro/sp-docs' target='_blank'>Azure Red Hat OpenShift product documentation</a>.<br><br>For your convenience, you can create the service principal using the following Azure CLI command with a local install or an Azure Cloud Shell. Copy the value of the <b>clientId</b> and <b>clientSecret</b> output from the following command into the corresponding fields. <b>az ad sp create-for-rbac --sdk-auth</b>."
+                                    "text": "An Azure Active Directory service principal is required for cluster creation. For more information on creating a service principal, consult the <a href='https://aka.ms/aro/sp-docs' target='_blank'>Azure Red Hat OpenShift product documentation</a>.<br><br>For your convenience, you can create the service principal using the following Azure CLI command with a local install or an Azure Cloud Shell. Copy the value of the <b>clientId</b> and <b>clientSecret</b> output from the following command into the corresponding fields. <b>out=sp-$(date +%s).json && az ad sp create-for-rbac --sdk-auth > ${out} && sleep 30 && cat ${out} | tr -d '\",'</b>"
                                 }
                             },
                             {
@@ -167,7 +167,7 @@
                                 "name": "UserSPGraphRequest",
                                 "type": "Microsoft.Solutions.GraphApiControl",
                                 "toolTip": "Obtain the objectId of the service principal",
-                                "condition": "[greater(length(steps('Cluster').createClusterInfo.aadClientId), 0)]",
+                                "condition": "[not(empty(steps('Cluster').createClusterInfo.aadClientId))]",
                                 "request": {
                                     "method": "GET",
                                     "path": "[concat('v1.0/servicePrincipals?$filter=appId eq \\'', steps('Cluster').createClusterInfo.aadClientId, '\\'')]",

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -135,7 +135,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "An Azure Active Directory service principal is required for cluster creation. For more information on creating a service principal, consult the <a href='https://aka.ms/aro/sp-docs' target='_blank'>Azure Red Hat OpenShift product documentation</a>.<br><br>For your convenience, you can create the service principal using the following Azure CLI command with a local install or an Azure Cloud Shell. Copy the value of the <b>clientId</b> and <b>clientSecret</b> output from the following command into the corresponding fields. <b>out=sp-$(date +%s).json && az ad sp create-for-rbac --sdk-auth > ${out} && sleep 30 && cat ${out} | tr -d '\",'</b>"
+                                    "text": "An Azure Active Directory service principal is required for cluster creation. For more information on creating a service principal, consult the <a href='https://aka.ms/aro/sp-docs' target='_blank'>Azure Red Hat OpenShift product documentation</a>.<br><br>For your convenience, you can create the service principal using the following Azure CLI command with a local install or an Azure Cloud Shell. Copy the value of the <b>clientId</b> and <b>clientSecret</b> output from the following command into the corresponding fields. <b>out=sp-$(date +%s).json && az ad sp create-for-rbac --sdk-auth > ${out} && sleep 30 && cat ${out} | tr -d '\",' && rm -rf ${out}</b>"
                                 }
                             },
                             {

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -135,7 +135,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "An Azure Active Directory service principal is required for cluster creation. For more information on creating a service principal, consult the <a href='https://aka.ms/aro/sp-docs' target='_blank'>Azure Red Hat OpenShift product documentation</a>.<br><br>For your convenience, you can create the service principal using the following Azure CLI command with a local install or an Azure Cloud Shell. Copy the value of the <b>clientId</b> and <b>clientSecret</b> output from the following command into the corresponding fields. <b>out=sp-$(date +%s).json && az ad sp create-for-rbac --sdk-auth > ${out} && sleep 30 && cat ${out} | tr -d '\",' && rm -rf ${out}</b>"
+                                    "text": "An Azure Active Directory service principal is required for cluster creation. For more information on creating a service principal, consult the <a href='https://aka.ms/aro/sp-docs' target='_blank'>Azure Red Hat OpenShift product documentation</a>.<br><br>For your convenience, you can create the service principal using the following Azure CLI command with a local install or an Azure Cloud Shell. Copy the value of the <b>clientId</b> and <b>clientSecret</b> output from the following command into the corresponding fields below. <br></br><code><b>out=sp-$(date +%s).json && az ad sp create-for-rbac --sdk-auth > ${out} && sleep 30 && cat ${out} | tr -d '\",' && rm -rf ${out}</b></code> <!-- https://github.com/WASdev/azure.liberty.aro/issues/79 -->"
                                 }
                             },
                             {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -243,6 +243,16 @@
             "properties": {
                 "AzCliVersion": "2.41.0",
                 "primaryScriptUri": "[uri(variables('const_scriptLocation'), concat('preflight.sh', parameters('_artifactsLocationSasToken')))]",
+                "environmentVariables": [
+                    {
+                        "name": "AAD_CLIENT_ID",
+                        "value": "[parameters('aadClientId')]"
+                    },
+                    {
+                        "name": "AAD_OBJECT_ID",
+                        "value": "[parameters('aadObjectId')]"
+                    }
+                ],
                 "cleanupPreference": "OnSuccess",
                 "retentionInterval": "P1D"
             }

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -173,6 +173,7 @@
         "name_clusterName": "[if(parameters('createCluster'), concat('cluster', variables('const_suffix')), parameters('clusterName'))]",
         "name_clusterVNetName": "[concat('vnet', variables('const_suffix'))]",
         "name_deploymentScriptName": "[concat('aroscript', variables('const_suffix'))]",
+        "name_preflightDSName": "[concat('preflight', variables('const_suffix'))]",
         "name_roleAssignmentName": "[guid(format('{0}{1}Role assignment in group{0}', resourceGroup().id, variables('ref_identityId')))]",
         "ref_identityId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('const_identityName'))]"
     },
@@ -225,13 +226,35 @@
             }
         },
         {
+            "type": "Microsoft.Resources/deploymentScripts",
+            "apiVersion": "${azure.apiVersion.deploymentScript}",
+            "name": "[variables('name_preflightDSName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Authorization/roleAssignments', variables('name_roleAssignmentName'))]"
+            ],
+            "kind": "AzureCLI",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('const_identityName')))]": {}
+                }
+            },
+            "properties": {
+                "AzCliVersion": "2.41.0",
+                "primaryScriptUri": "[uri(variables('const_scriptLocation'), concat('preflight.sh', parameters('_artifactsLocationSasToken')))]",
+                "cleanupPreference": "OnSuccess",
+                "retentionInterval": "P1D"
+            }
+        },
+        {
            "condition": "[parameters('createCluster')]",
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "${azure.apiVersion.virtualNetworks}",
             "name": "[variables('name_clusterVNetName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Authorization/roleAssignments', variables('name_roleAssignmentName'))]"
+                "[resourceId('Microsoft.Resources/deploymentScripts', variables('name_preflightDSName'))]"
             ],
             "properties": {
                 "addressSpace": {

--- a/src/main/scripts/preflight.sh
+++ b/src/main/scripts/preflight.sh
@@ -16,6 +16,12 @@
 
 set -Eeuo pipefail
 
+# Fail fast the deployment if object Id of the service principal is empty
+if [[ -z "$AAD_OBJECT_ID" ]]; then
+  echo "The object Id of the service principal you just created is not successfully retrieved, please retry another deployment using its client id ${AAD_CLIENT_ID}." >&2
+  exit 1
+fi
+
 # Wait 30s for service principal available after creation
 # See https://github.com/WASdev/azure.liberty.aro/issues/59 & https://github.com/WASdev/azure.liberty.aro/issues/79
 sleep 30

--- a/src/main/scripts/preflight.sh
+++ b/src/main/scripts/preflight.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -Eeuo pipefail
+
+# Wait 30s for service principal available after creation
+# See https://github.com/WASdev/azure.liberty.aro/issues/59 & https://github.com/WASdev/azure.liberty.aro/issues/79
+sleep 30


### PR DESCRIPTION
## Description

The PR is to fix the following issues:
* Resolve #79 

## Change summary

* Update instructions about creating service principal by adding `sleep 30`
* Add a preflight script which 
  * fails the deployment if object Id of the service principal is empty
  * wait 30s to make the service principal is available in the role assignment later

## Testing

* Deploy ARO 4 + WLO + Sample app: [integration-test-33](https://github.com/majguo/azure.liberty.aro/actions/runs/3636397576)
* Deploy ARO 4 using [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro)

## UI changes review

The command to create service principal is updated from `az ad sp create-for-rbac --sdk-auth` to `out=sp-$(date +%s).json && az ad sp create-for-rbac --sdk-auth > ${out} && sleep 30 && cat ${out} | tr -d '",' && rm -rf ${out}`:

![image](https://user-images.githubusercontent.com/10357495/206364758-858a8659-2878-40c1-81f0-26cc2c8d1701.png)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>