### PR TITLE
Separate into multiple lines to work around line break issue

### DIFF
--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -135,7 +135,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "An Azure Active Directory service principal is required for cluster creation. For more information on creating a service principal, consult the <a href='https://aka.ms/aro/sp-docs' target='_blank'>Azure Red Hat OpenShift product documentation</a>.<br><br>For your convenience, you can create the service principal using the following Azure CLI command with a local install or an Azure Cloud Shell. Copy the value of the <b>clientId</b> and <b>clientSecret</b> output from the following command into the corresponding fields below. <br></br><code><b>out=sp-$(date +%s).json && az ad sp create-for-rbac --sdk-auth > ${out} && sleep 30 && cat ${out} | tr -d '\",' && rm -rf ${out}</b></code> <!-- https://github.com/WASdev/azure.liberty.aro/issues/79 -->"
+                                    "text": "An Azure Active Directory service principal is required for cluster creation. For more information on creating a service<br>principal, consult the <a href='https://aka.ms/aro/sp-docs' target='_blank'>Azure Red Hat OpenShift product documentation</a>.<br><br>For your convenience, you can create the service principal using the following Azure CLI command with a local install or<br>an Azure Cloud Shell. Copy the value of the <b>clientId</b> and <b>clientSecret</b> output from the following command into the<br>corresponding fields below. <br></br><code><b>out=sp-$(date +%s).json && az ad sp create-for-rbac --sdk-auth > ${out} && sleep 30 \\<br>&& cat ${out} | tr -d '\",' && rm -rf ${out}</b></code> <!-- https://github.com/WASdev/azure.liberty.aro/issues/79 -->"
                                 }
                             },
                             {
@@ -277,7 +277,7 @@
                         "type": "Microsoft.Common.InfoBox",
                         "options": {
                             "icon": "Info",
-                            "text": "I accept the terms on the license agreement corresponding to the version of IBM Program in the application container by setting this value to true. See <a href='https://ibm.biz/was-license' target='_blank'>https://ibm.biz/was-license</a> for the license agreement applicable to this IBM Program. You must accept the license for the installation to work."
+                            "text": "I accept the terms on the license agreement corresponding to the version of IBM Program in the application container<br>by setting this value to true. See <a href='https://ibm.biz/was-license' target='_blank'>https://ibm.biz/was-license</a> for the license agreement applicable to this IBM Program.<br>You must accept the license for the installation to work."
                         },
                         "visible": "[and(bool(steps('Application').deployWLO), bool(steps('Application').deployApplication))]"
                     },
@@ -376,7 +376,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "Please provide a public image which is accessible without credentials."
+                                    "text": "Please provide a public image which is accessible without credentials. If you input a fully qualified container image path<br>containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'.<br>For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty',<br>and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'."
                                 },
                                 "visible": "[equals(steps('Application').appImageInfo.appImageOption, '1')]"
                             },


### PR DESCRIPTION
Work around `Declarative Info box cuts off the message` issue by manually separating long line into multiple lines. Also added more information to `imagePathInfo` which is copied from `azure.liberty.aks` offer.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>