### PR TITLE
Update OLO to 1.2.0

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -115,8 +115,9 @@ jobs:
               echo "Invalid value of appEndpoint: ${appEndpoint}"
               exit 1
             fi
-            curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appEndpoint
-            if [[ $? -ne 0 ]]; then
+            httpCode=$(curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused --write-out '%{http_code}' --silent --output /dev/null $appEndpoint)
+            echo "http_code is $httpCode"
+            if [ "$httpCode" -ne 200 ]; then
               echo "Failed to access ${appEndpoint}."
               exit 1
             fi

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.44</version>
+    <version>1.0.45</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -305,10 +305,12 @@ if [[ $? -ne 0 ]]; then
 fi
 oc project $Project_Name
 
-# Choose right template
+# Choose right template & protocol
 appDeploymentTemplate=open-liberty-application.yaml.template
+protocol=https
 if [ "$DEPLOY_WLO" = True ]; then
     appDeploymentTemplate=websphere-liberty-application.yaml.template
+    protocol=http
 fi
 
 appDeploymentFile=liberty-application.yaml
@@ -364,7 +366,7 @@ fi
 result=$(jq -n -c --arg consoleUrl $consoleUrl '{consoleUrl: $consoleUrl}')
 result=$(echo "$result" | jq --arg appDeploymentYaml "$appDeploymentYaml" '{"appDeploymentYaml": $appDeploymentYaml} + .')
 if [ "$deployApplication" = True ]; then
-    result=$(echo "$result" | jq --arg appEndpoint "$appEndpoint" '{"appEndpoint": $appEndpoint} + .')
+    result=$(echo "$result" | jq --arg appEndpoint "$protocol://$appEndpoint" '{"appEndpoint": $appEndpoint} + .')
 fi
 echo "Result is: $result" >> $logFile
 echo $result > $AZ_SCRIPTS_OUTPUT_PATH

--- a/src/main/scripts/open-liberty-application.yaml.template
+++ b/src/main/scripts/open-liberty-application.yaml.template
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-apiVersion: apps.openliberty.io/v1beta2
+apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:
   name: ${Application_Name}

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -18,9 +18,9 @@ metadata:
   name: open-liberty-certified
   namespace: openshift-operators
 spec:
-  channel: beta2
+  channel: v1.2
   installPlanApproval: Automatic
   name: open-liberty-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: open-liberty-operator.v0.8.0
+  startingCSV: open-liberty-operator.v1.2.0


### PR DESCRIPTION
The PR is to resolve #91 (and also resolve #68) which updates OLO to 1.2.0 and CR `OpenLibertyApplication` to `apps.openliberty.io/v1`.

## Testing

The following workflow runs complete successfully:
* Install OLO: [integration-test-38](https://github.com/majguo/azure.liberty.aro/actions/runs/4987499936)
* Install WLO: [integration-test-39](https://github.com/majguo/azure.liberty.aro/actions/runs/4988233402)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>