### PR TITLE
Remove comment from mainTemplate.json

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -77,7 +77,6 @@ jobs:
           path: ${{steps.artifact_file.outputs.artifactPath}}
       - name: Update offer artifact
         uses: microsoft/microsoft-partner-center-github-action@v3
-        if: ${{ github.repository_owner  == 'WASdev' }}
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.47</version>
+    <version>1.0.48</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -1,5 +1,3 @@
-//      Copyright (c) IBM Corporation.
-//      Copyright (c) Microsoft Corporation.
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",

--- a/src/main/scripts/catalog-source.yaml
+++ b/src/main/scripts/catalog-source.yaml
@@ -1,6 +1,5 @@
 # Copyright (c) IBM Corporation.
 # Copyright (c) Microsoft Corporation.
-#      Copyright (c) Microsoft Corporation.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -1,6 +1,5 @@
 # Copyright (c) IBM Corporation.
 # Copyright (c) Microsoft Corporation.
-#      Copyright (c) Microsoft Corporation.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.


### PR DESCRIPTION
The most recent offer publish in Partner Center failed as the support replied that the `mainTemplate.json` is invalid. Th PR is to remove comment from `mainTemplate.json` to try fix the issue.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>