### PR TITLE
Upgrade olo to 1.2.2 manually

### DIFF
--- a/docs/trouble-shooting-guide.md
+++ b/docs/trouble-shooting-guide.md
@@ -29,3 +29,15 @@ To monitor the deployment process and check the log data, you can inspect the ru
    ![Container instance is terminated and the connection is closed](./media/trouble-shooting-guide/container-instance-terminated.png)
 
 Besides, the Azure storage account and Azure container instance will be kept for one day if the deployment script finished with errors. So, user can inspect the runtime log after the deployment, starting from step #3.
+
+## Download the log file
+
+However, if you want to download the log file into your local computer before the storage account is removed, reference the following steps:
+
+1. Find your resource group where the deployment is located.
+1. Select Deployment Script prefixed with **aroscript**.
+1. Search the web page with keyword **Storage account**, select the storage account you find.
+1. Under **Data storage** in the left navigation panel, select **File shares**. You will see one file share listed. Select it.
+1. Select **Browse** in the left navigation panel. You will see two directories. Select **azscriptinput**.
+1. You will see a list of files. Select **deployment.log** which is the log file you're looking for.
+1. In the pop up **File properties**, select **Download**. The log file will be downloaded to your local computer.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.48</version>
+    <version>1.0.49</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -24,4 +24,4 @@ spec:
   name: open-liberty-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: open-liberty-operator.v1.2.1
+  startingCSV: open-liberty-operator.v1.2.2


### PR DESCRIPTION
The PR is to fix the most recent deployment issue reported by @edburns and @m-reza-rahman. Per investigation, the root cause is that when the new version `1.2.2` of OLO is available, the `startingCSV` doesn't work with `open-liberty-operator.v1.2.1` anymore. Updating to `open-liberty-operator.v1.2.2` solves the issue. 

Please see the similar issue for olo `1.2.1` described in https://github.com/WASdev/azure.liberty.aro/pull/97#issuecomment-1626388789.

## Testing

I successfully installed OLO 1.2.2 with the fix of the PR and also successfully deployed the sample app.
* ![image](https://github.com/WASdev/azure.liberty.aro/assets/10357495/d1b7ca41-9775-4917-9c90-37bd06b6e3b2)
* ![image](https://github.com/WASdev/azure.liberty.aro/assets/10357495/29b90a64-e9f1-4c05-b57c-cce8240b841f)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>