### PR TITLE
Revert vNetRoleAssignment version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
         <azure.apiVersion.deployments>2023-07-01</azure.apiVersion.deployments>
         <azure.apiVersion.virtualNetworks>2023-06-01</azure.apiVersion.virtualNetworks>
-        <azure.apiVersion.vNetRoleAssignment>2022-04-01</azure.apiVersion.vNetRoleAssignment>
+        <azure.apiVersion.vNetRoleAssignment>2018-09-01-preview</azure.apiVersion.vNetRoleAssignment>
         <azure.apiVersion.aroCluster>2023-04-01</azure.apiVersion.aroCluster>
         <azure.apiVersion.roleAssignment>2022-04-01</azure.apiVersion.roleAssignment>
         <azure.apiVersion.userAssignedIdentities>2023-01-31</azure.apiVersion.userAssignedIdentities>


### PR DESCRIPTION
for #102 

ARO Preview failed with:
No registered resource provider found for location 'eastus' and API version '2023-06-01' for type 'roleAssignments'. The supported api-versions are '2014-04-01-preview, 2014-07-01-preview, 2014-10-01-preview, 2015-05-01-preview, 2015-06-01, 2015-07-01, 2016-07-01, 2017-05-01, 2017-09-01, 2017-10-01-preview, 2018-01-01-preview, 2018-07-01, 2018-09-01-preview, 2018-12-01-preview, 2019-04-01-preview, 2020-03-01-preview, 2020-04-01-preview, 2020-08-01-preview, 2020-10-01-preview, 2021-04-01-preview, 2022-01-01-preview, 2022-04-01'. The supported locations are ''. (Code: NoRegisteredProviderFound)

