### PR TITLE
Fix deployment failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.50</version>
+    <version>1.0.51</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -258,18 +258,21 @@ apk update
 apk add gettext
 apk add apache2-utils
 
-# Install the OpenShift CLI
-wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz -q -P ~
-mkdir ~/openshift
-tar -zxvf ~/openshift-client-linux.tar.gz -C ~/openshift
-echo 'export PATH=$PATH:~/openshift' >> ~/.bash_profile && source ~/.bash_profile
-
-# Sign in to cluster
+# Retrieve cluster credentials and api/console URLs
 credentials=$(az aro list-credentials -g $clusterRGName -n $clusterName -o json)
 kubeadminUsername=$(echo $credentials | jq -r '.kubeadminUsername')
 kubeadminPassword=$(echo $credentials | jq -r '.kubeadminPassword')
 apiServerUrl=$(az aro show -g $clusterRGName -n $clusterName --query 'apiserverProfile.url' -o tsv)
 consoleUrl=$(az aro show -g $clusterRGName -n $clusterName --query 'consoleProfile.url' -o tsv)
+
+# Install the OpenShift CLI
+downloadUrl=$(echo $consoleUrl | sed -e "s/https:\/\/console/https:\/\/downloads/g")
+wget ${downloadUrl}amd64/linux/oc.tar -q -P ~
+mkdir ~/openshift
+tar xvf ~/oc.tar -C ~/openshift 
+echo 'export PATH=$PATH:~/openshift' >> ~/.bash_profile && source ~/.bash_profile
+
+# Sign in to cluster
 wait_login_complete $kubeadminUsername $kubeadminPassword "$apiServerUrl" $logFile
 if [[ $? -ne 0 ]]; then
   echo "Failed to sign into the cluster with ${kubeadminUsername}." >&2


### PR DESCRIPTION
The PR is to fix #107 (liberty on aro offer deployment failure) which was caused by the issue that the installed `oc` client doesn't work. The fix is inspired by [Installing the OpenShift CLI on Linux using the web console](https://docs.openshift.com/container-platform/4.14/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli-web-console_cli-developer-commands).

## Test

The deployment succeeded with the fix, see [integration-test](https://github.com/majguo/azure.liberty.aro/actions/runs/7442786774).

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>