### PR TITLE
Fix issues detected when running integration tests against PR #108

### DIFF
--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -267,7 +267,7 @@ consoleUrl=$(az aro show -g $clusterRGName -n $clusterName --query 'consoleProfi
 
 # Install the OpenShift CLI
 downloadUrl=$(echo $consoleUrl | sed -e "s/https:\/\/console/https:\/\/downloads/g")
-wget ${downloadUrl}amd64/linux/oc.tar -q -P ~
+wget --no-check-certificate ${downloadUrl}amd64/linux/oc.tar -q -P ~
 mkdir ~/openshift
 tar xvf ~/oc.tar -C ~/openshift 
 echo 'export PATH=$PATH:~/openshift' >> ~/.bash_profile && source ~/.bash_profile

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -19,7 +19,7 @@ metadata:
   name: open-liberty-certified
   namespace: openshift-operators
 spec:
-  channel: v1.2
+  channel: v1.3
   installPlanApproval: Automatic
   name: open-liberty-certified
   source: certified-operators


### PR DESCRIPTION
This PR is to addressing issues detected when running integration tests against PR #108:
* OLO installation failed due to the channel is not updated to `v1.3`
* wget failed due to `certificate verification failed: self signed certificate in certificate chain`

## Tests

The integration test pipeline ran successfully with the fix included in this PR:
* [integration-test](https://github.com/majguo/azure.liberty.aro/actions/runs/7523685431)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>