### PR TITLE
Fix deployment failure

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -197,5 +197,5 @@ jobs:
         run: |
             echo "delete resource group: " ${{ env.testResourceGroup }}
             az group delete -n ${{ env.testResourceGroup }} --yes
-            echo "delete app with clientId: " ${clientId}
-            az ad app delete --id ${needs.integration-test.outputs.clientId}
+            echo "delete app with clientId: " ${{ needs.integration-test.outputs.clientId }}
+            az ad app delete --id ${{ needs.integration-test.outputs.clientId }}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.52</version>
+    <version>1.0.53</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -24,4 +24,4 @@ spec:
   name: open-liberty-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: open-liberty-operator.v1.3.0
+  startingCSV: open-liberty-operator.v1.3.1


### PR DESCRIPTION
The PR is to fix #110 (liberty on aro offer deployment failure) which was caused by the issue that the Open Liberty Operator can't be installed due to the `startingCSV` is updgrade to `open-liberty-operator.v1.3.1`. It also contains another fix for the integration-test pipeline.

## Test

The deployment succeeded with the fix, see [integration-test-51](https://github.com/majguo/azure.liberty.aro/actions/runs/8418049425).

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>