### PR TITLE
Fix deployment failure when using an existing ARO cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.53</version>
+    <version>1.0.54</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -220,23 +220,54 @@
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('const_identityName'))]"
             ],
             "properties": {
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
                 "mode": "Incremental",
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "roleAssignmentName": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "contribRole": {
+                            "type": "string"
+                        },
+                        "principalId": {
+                            "type": "string"
+                        }
+                    },
                     "resources": [
                         {
                             "type": "Microsoft.Authorization/roleAssignments",
                             "apiVersion": "${azure.apiVersion.roleAssignment}",
-                            "name": "[variables('name_roleAssignmentName')]",
-                            "scope": "[concat(subscription().id, '/resourceGroups/', variables('const_clusterRGName'))]",
+                            "name": "[parameters('roleAssignmentName')]",
+                            "scope": "[parameters('scope')]",
                             "properties": {
-                                "roleDefinitionId": "[variables('const_contribRole')]",
-                                "principalId": "[reference(variables('ref_identityId')).principalId]",
+                                "roleDefinitionId": "[parameters('contribRole')]",
+                                "principalId": "[parameters('principalId')]",
                                 "principalType": "ServicePrincipal"
                             }
                         }
                     ]
+                },
+                "parameters": {
+                    "roleAssignmentName": {
+                        "value": "[variables('name_roleAssignmentName')]"
+                    },
+                    "scope": {
+                        "value": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', variables('const_clusterRGName'))]"
+                    },
+                    "contribRole": {
+                        "value": "[variables('const_contribRole')]"
+                    },
+                    "principalId": {
+                        "value": "[reference(variables('ref_identityId')).principalId]"
+                    }
                 }
             }
         },

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -216,6 +216,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion.deployments}",
             "name": "roleAssignmentDeployment",
+            "resourceGroup": "[variables('const_clusterRGName')]",
             "dependsOn": [
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('const_identityName'))]"
             ],
@@ -231,10 +232,7 @@
                         "roleAssignmentName": {
                             "type": "string"
                         },
-                        "scope": {
-                            "type": "string"
-                        },
-                        "contribRole": {
+                        "contributorRole": {
                             "type": "string"
                         },
                         "principalId": {
@@ -246,9 +244,8 @@
                             "type": "Microsoft.Authorization/roleAssignments",
                             "apiVersion": "${azure.apiVersion.roleAssignment}",
                             "name": "[parameters('roleAssignmentName')]",
-                            "scope": "[parameters('scope')]",
                             "properties": {
-                                "roleDefinitionId": "[parameters('contribRole')]",
+                                "roleDefinitionId": "[parameters('contributorRole')]",
                                 "principalId": "[parameters('principalId')]",
                                 "principalType": "ServicePrincipal"
                             }
@@ -259,10 +256,7 @@
                     "roleAssignmentName": {
                         "value": "[variables('name_roleAssignmentName')]"
                     },
-                    "scope": {
-                        "value": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', variables('const_clusterRGName'))]"
-                    },
-                    "contribRole": {
+                    "contributorRole": {
                         "value": "[variables('const_contribRole')]"
                     },
                     "principalId": {
@@ -277,7 +271,7 @@
             "name": "[variables('name_preflightDSName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'roleAssignmentDeployment')]"
+                "[resourceId(variables('const_clusterRGName'), 'Microsoft.Resources/deployments', 'roleAssignmentDeployment')]"
             ],
             "kind": "AzureCLI",
             "identity": {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -174,7 +174,7 @@
         "name_clusterVNetName": "[concat('vnet', variables('const_suffix'))]",
         "name_deploymentScriptName": "[concat('aroscript', variables('const_suffix'))]",
         "name_preflightDSName": "[concat('preflight', variables('const_suffix'))]",
-        "name_roleAssignmentName": "[guid(format('{0}{1}Role assignment in group{0}', resourceGroup().id, variables('ref_identityId')))]",
+        "name_roleAssignmentName": "[guid(format('{0}{1}Role assignment in group{0}', variables('const_clusterRGName'), variables('ref_identityId')))]",
         "ref_identityId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('const_identityName'))]"
     },
     "resources": [
@@ -213,16 +213,31 @@
             "location": "[parameters('location')]"
         },
         {
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "${azure.apiVersion.roleAssignment}",
-            "name": "[variables('name_roleAssignmentName')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "${azure.apiVersion.deployments}",
+            "name": "roleAssignmentDeployment",
             "dependsOn": [
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('const_identityName'))]"
             ],
             "properties": {
-                "roleDefinitionId": "[variables('const_contribRole')]",
-                "principalId": "[reference(variables('ref_identityId')).principalId]",
-                "principalType": "ServicePrincipal"
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.Authorization/roleAssignments",
+                            "apiVersion": "${azure.apiVersion.roleAssignment}",
+                            "name": "[variables('name_roleAssignmentName')]",
+                            "scope": "[concat(subscription().id, '/resourceGroups/', variables('const_clusterRGName'))]",
+                            "properties": {
+                                "roleDefinitionId": "[variables('const_contribRole')]",
+                                "principalId": "[reference(variables('ref_identityId')).principalId]",
+                                "principalType": "ServicePrincipal"
+                            }
+                        }
+                    ]
+                }
             }
         },
         {
@@ -231,7 +246,7 @@
             "name": "[variables('name_preflightDSName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Authorization/roleAssignments', variables('name_roleAssignmentName'))]"
+                "[resourceId('Microsoft.Resources/deployments', 'roleAssignmentDeployment')]"
             ],
             "kind": "AzureCLI",
             "identity": {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -245,6 +245,10 @@
                 "primaryScriptUri": "[uri(variables('const_scriptLocation'), concat('preflight.sh', parameters('_artifactsLocationSasToken')))]",
                 "environmentVariables": [
                     {
+                        "name": "CREATE_CLUSTER",
+                        "value": "[parameters('createCluster')]"
+                    },
+                    {
                         "name": "AAD_CLIENT_ID",
                         "value": "[parameters('aadClientId')]"
                     },

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -213,9 +213,23 @@
             "location": "[parameters('location')]"
         },
         {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "${azure.apiVersion.roleAssignment}",
+            "name": "[variables('name_roleAssignmentName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('const_identityName'))]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('const_contribRole')]",
+                "principalId": "[reference(variables('ref_identityId')).principalId]",
+                "principalType": "ServicePrincipal"
+            }
+        },
+        {
+            "condition": "[not(parameters('createCluster'))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion.deployments}",
-            "name": "roleAssignmentDeployment",
+            "name": "[format('{0}-deployment', variables('name_roleAssignmentName'))]",
             "resourceGroup": "[variables('const_clusterRGName')]",
             "dependsOn": [
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('const_identityName'))]"
@@ -254,7 +268,7 @@
                 },
                 "parameters": {
                     "roleAssignmentName": {
-                        "value": "[variables('name_roleAssignmentName')]"
+                        "value": "[format('{0}-roleAssignment', variables('name_roleAssignmentName'))]"
                     },
                     "contributorRole": {
                         "value": "[variables('const_contribRole')]"
@@ -271,7 +285,8 @@
             "name": "[variables('name_preflightDSName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "[resourceId(variables('const_clusterRGName'), 'Microsoft.Resources/deployments', 'roleAssignmentDeployment')]"
+                "[resourceId('Microsoft.Authorization/roleAssignments', variables('name_roleAssignmentName'))]",
+                "[resourceId(variables('const_clusterRGName'), 'Microsoft.Resources/deployments', format('{0}-deployment', variables('name_roleAssignmentName')))]"
             ],
             "kind": "AzureCLI",
             "identity": {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -174,7 +174,8 @@
         "name_clusterVNetName": "[concat('vnet', variables('const_suffix'))]",
         "name_deploymentScriptName": "[concat('aroscript', variables('const_suffix'))]",
         "name_preflightDSName": "[concat('preflight', variables('const_suffix'))]",
-        "name_roleAssignmentName": "[guid(format('{0}{1}Role assignment in group{0}', variables('const_clusterRGName'), variables('ref_identityId')))]",
+        "name_roleAssignmentName": "[guid(format('{0}{1}Role assignment in group{0}', resourceGroup().name, variables('ref_identityId')))]",
+        "name_roleAssignmentToCluserRGName": "[guid(format('{0}{1}Role assignment in group{0}', variables('const_clusterRGName'), variables('ref_identityId')))]",
         "ref_identityId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('const_identityName'))]"
     },
     "resources": [
@@ -229,7 +230,7 @@
             "condition": "[not(parameters('createCluster'))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion.deployments}",
-            "name": "[format('{0}-deployment', variables('name_roleAssignmentName'))]",
+            "name": "[variables('name_roleAssignmentToCluserRGName')]",
             "resourceGroup": "[variables('const_clusterRGName')]",
             "dependsOn": [
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('const_identityName'))]"
@@ -268,7 +269,7 @@
                 },
                 "parameters": {
                     "roleAssignmentName": {
-                        "value": "[format('{0}-roleAssignment', variables('name_roleAssignmentName'))]"
+                        "value": "[variables('name_roleAssignmentToCluserRGName')]"
                     },
                     "contributorRole": {
                         "value": "[variables('const_contribRole')]"
@@ -286,7 +287,7 @@
             "location": "[parameters('location')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Authorization/roleAssignments', variables('name_roleAssignmentName'))]",
-                "[resourceId(variables('const_clusterRGName'), 'Microsoft.Resources/deployments', format('{0}-deployment', variables('name_roleAssignmentName')))]"
+                "[resourceId(variables('const_clusterRGName'), 'Microsoft.Resources/deployments', variables('name_roleAssignmentToCluserRGName'))]"
             ],
             "kind": "AzureCLI",
             "identity": {

--- a/src/main/scripts/preflight.sh
+++ b/src/main/scripts/preflight.sh
@@ -17,12 +17,14 @@
 
 set -Eeuo pipefail
 
-# Fail fast the deployment if object Id of the service principal is empty
-if [[ -z "$AAD_OBJECT_ID" ]]; then
-  echo "The object Id of the service principal you just created is not successfully retrieved, please retry another deployment using its client id ${AAD_CLIENT_ID}." >&2
-  exit 1
-fi
+if [[ "${CREATE_CLUSTER,,}" == "true" ]]; then
+  # Fail fast the deployment if object Id of the service principal is empty
+  if [[ -z "$AAD_OBJECT_ID" ]]; then
+    echo "The object Id of the service principal you just created is not successfully retrieved, please retry another deployment using its client id ${AAD_CLIENT_ID}." >&2
+    exit 1
+  fi
 
-# Wait 30s for service principal available after creation
-# See https://github.com/WASdev/azure.liberty.aro/issues/59 & https://github.com/WASdev/azure.liberty.aro/issues/79
-sleep 30
+  # Wait 30s for service principal available after creation
+  # See https://github.com/WASdev/azure.liberty.aro/issues/59 & https://github.com/WASdev/azure.liberty.aro/issues/79
+  sleep 30
+fi


### PR DESCRIPTION
The PR is to fix #114 (liberty on aro offer deployment failure) which was caused by the issue that the inappropriate check during the pre-filght and missed role assignment on the cluster resource group for the uami of the deployment script, when using an existing ARO cluster.

## Test

The deployment succeeded with the fix, see [integration-test-72](https://github.com/majguo/azure.liberty.aro/actions/runs/8524049338) which deployed a new ARO cluster.

Then I deployed the fix to the testing offer and use its [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aro) to verify the deployment with the existing ARO cluster, which also succeeded.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>