### PR TITLE
Fix deployment failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.56</version>
+    <version>1.0.57</version>
 
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -24,4 +24,4 @@ spec:
   name: open-liberty-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: open-liberty-operator.v1.3.1
+  startingCSV: open-liberty-operator.v1.3.2

--- a/src/main/scripts/preflight.sh
+++ b/src/main/scripts/preflight.sh
@@ -24,7 +24,7 @@ if [[ "${CREATE_CLUSTER,,}" == "true" ]]; then
     exit 1
   fi
 
-  # Wait 30s for service principal available after creation
+  # Wait 60s for service principal available after creation
   # See https://github.com/WASdev/azure.liberty.aro/issues/59 & https://github.com/WASdev/azure.liberty.aro/issues/79
   sleep 60
 fi

--- a/src/main/scripts/preflight.sh
+++ b/src/main/scripts/preflight.sh
@@ -26,5 +26,5 @@ if [[ "${CREATE_CLUSTER,,}" == "true" ]]; then
 
   # Wait 30s for service principal available after creation
   # See https://github.com/WASdev/azure.liberty.aro/issues/59 & https://github.com/WASdev/azure.liberty.aro/issues/79
-  sleep 30
+  sleep 60
 fi


### PR DESCRIPTION
The PR is to fix #119 (liberty on aro offer deployment failure) which was caused by the issue that the Open Liberty Operator can't be installed due to the `startingCSV` is updgrade to `open-liberty-operator.v1.3.2`. It also contains another fix for intermittent deployment failure of ARO cluster creation.

## Test

The deployment succeeded with the fix, see [integration-test-80](https://github.com/majguo/azure.liberty.aro/actions/runs/9458710637) which deployed **Open Liberty Operator** 1.3.2.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>