### PR TITLE
Update to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -152,7 +152,7 @@ jobs:
           echo "##[set-output name=artifactName;]${artifactName}"
           echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
       - name: Archive ${{ env.repoName }} template
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: success()
         with:
           name: ${{steps.artifact_file.outputs.artifactName}}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -75,7 +75,7 @@ jobs:
           echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
           echo "##[set-output name=artifactVersion;]${version}"
       - name: Archive ${{ env.repoName }} template
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: success()
         with:
           name: ${{steps.artifact_file.outputs.artifactName}}


### PR DESCRIPTION
The PR is to fix the issue detected in https://github.com/WASdev/azure.websphere-traditional.singleserver/actions/runs/10824397307/job/30031567803:
![image](https://github.com/user-attachments/assets/d408e279-1bcc-4d16-9a50-62eccf5c2cdf)

Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/.
Testing: see https://github.com/majguo/azure.liberty.aro/actions/runs/10840712951.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>