### PR TITLE
Update to olo 1.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.58</version>
+    <version>1.0.59</version>
 
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -24,4 +24,4 @@ spec:
   name: open-liberty-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: open-liberty-operator.v1.3.2
+  startingCSV: open-liberty-operator.v1.3.3


### PR DESCRIPTION
The PR is to fix the OLO deployment issue by updating it to `1.3.3`.

Integration test succeeded: https://github.com/majguo/azure.liberty.aro/actions/runs/10914188313

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>