### PR TITLE
Enable deployment to non-empty resource groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.0.60</version>
+    <version>1.1.0</version>
 
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -3,6 +3,13 @@
     "handler": "Microsoft.Azure.CreateUIDef",
     "version": "0.1.2-preview",
     "parameters": {
+        "config": {
+            "basics": {
+                "resourceGroup": {
+                    "allowExisting": true
+                }
+            }
+        },
         "basics": [
             {
                 "name": "infoForBeforeDeployment",


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-troubleshoot#publishing-fails-with-resourcegroup-allowexisting-must-be-set-to-true-in-the-createuidefinitions-config-error.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>