### PR TITLE
Update version of OLO to 1.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -24,4 +24,4 @@ spec:
   name: open-liberty-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: open-liberty-operator.v1.4.0
+  startingCSV: open-liberty-operator.v1.4.1


### PR DESCRIPTION
The version of Open Liberty Operator shipped with Azure Red Hat OpenShift cluster deployed by the offer has been upgrade to `1.4.1`, which caused the deployment failure as the offer tries to deploy OLO `1.4.0`. The PR is to update the OLO version according to fix the deployment failure.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>