### PR TITLE
Fix deployment issues: update version of OLO to `1.4.1` and install missing library for `oc` cmdlet

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,6 +28,11 @@ on:
         required: true
         type: boolean
         default: true
+      location:
+        description: 'Location of the Azure resources'
+        required: true
+        type: string
+        default: 'eastus'
   # Allows you to run this workflow using GitHub workflow dispatch APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.liberty.aro
@@ -48,7 +53,7 @@ env:
   msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
   testResourceGroup: libertyAroTestRG-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
   testDeploymentName: libertyAroTestDeployment-${{ github.run_id }}-${{ github.run_number }}
-  location: eastus
+  location: ${{ github.event.inputs.location || 'eastus' }}
 jobs:
   integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -82,7 +82,7 @@ jobs:
           path: ${{steps.artifact_file.outputs.artifactPath}}
       - name: Update offer artifact
         if: ${{ inputs.updateOfferArtifact == true || github.event.client_payload.updateOfferArtifact == true }}
-        uses: microsoft/microsoft-partner-center-github-action@v3
+        uses: microsoft/microsoft-partner-center-github-action@v3.2
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
 
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -368,6 +368,15 @@ apk update
 apk add gettext
 apk add apache2-utils
 
+# Check if /usr/lib/libresolv.so.2 exists that is required by the OpenShift CLI
+if [ ! -f /usr/lib/libresolv.so.2 ]; then
+    echo "Install gcompat package which provides /usr/lib/libresolv.so.2"
+    apk add gcompat
+    
+    echo "Create a symbolic link for /usr/lib/libresolv.so.2"
+    ln -sf /lib/libgcompat.so.0 /usr/lib/libresolv.so.2
+fi
+
 # Retrieve cluster credentials and api/console URLs
 credentials=$(az aro list-credentials -g $clusterRGName -n $clusterName -o json)
 kubeadminUsername=$(echo $credentials | jq -r '.kubeadminUsername')

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -19,7 +19,7 @@ metadata:
   name: open-liberty-certified
   namespace: openshift-operators
 spec:
-  channel: v1.3
+  channel: v1.4
   installPlanApproval: Automatic
   name: open-liberty-certified
   source: certified-operators


### PR DESCRIPTION
This pull request includes several updates to configuration files, scripts, and versioning to fix deployment issues, enhance functionality and compatibility. The most important changes are grouped by theme below:

### Fix issue that `oc` cmdlet fails to execute:
* [`src/main/scripts/install.sh`](diffhunk://#diff-b045766e8db5f9b67ba7d8d2e7cfee92679195513f737f83c5e9bfe943de4b40R371-R379): Added a check for the existence of `/usr/lib/libresolv.so.2` and installed the `gcompat` package if necessary, including creating a symbolic link to ensure compatibility with the OpenShift CLI.

### Fix the issue that OLO installation fails:
* [`src/main/scripts/open-liberty-operator-subscription.yaml`](diffhunk://#diff-f6fd7ee96bc830c1d1cd694c2a7ae5ad7ebb0fb49246033f84bb0e053945a4dcL22-R22): Updated the subscription channel from `v1.3` to `v1.4` for the `open-liberty-certified` operator.

### Workflow enhancements:
* [`.github/workflows/integration-test.yaml`](diffhunk://#diff-b6766eb8febc0c51651250cd0cdfb44c4f0d3256470d88e62bf82fd46aa73ae0R31-R35): Added a new input parameter `location` for specifying the location of Azure resources, and modified the `env` section to use this input parameter. [[1]](diffhunk://#diff-b6766eb8febc0c51651250cd0cdfb44c4f0d3256470d88e62bf82fd46aa73ae0R31-R35) [[2]](diffhunk://#diff-b6766eb8febc0c51651250cd0cdfb44c4f0d3256470d88e62bf82fd46aa73ae0L51-R56)
* [`.github/workflows/package.yaml`](diffhunk://#diff-154ccb2e01a195c7f4431e94b51c9f2e69bcbda5891ebfbc53b99719cd46e4e2L85-R85): Updated the `microsoft-partner-center-github-action` to version `v3.2` for improved functionality.

### Test

integration-test passed: https://github.com/majguo/azure.liberty.aro/actions/runs/13304673571

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>