### PR TITLE
Update actions version with pinned hash value 

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -157,7 +157,7 @@ jobs:
           echo "##[set-output name=artifactName;]${artifactName}"
           echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
       - name: Archive ${{ env.repoName }} template
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: success()
         with:
           name: ${{steps.artifact_file.outputs.artifactName}}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -157,7 +157,7 @@ jobs:
           echo "##[set-output name=artifactName;]${artifactName}"
           echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
       - name: Archive ${{ env.repoName }} template
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4.6.2
         if: success()
         with:
           name: ${{steps.artifact_file.outputs.artifactName}}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -75,7 +75,7 @@ jobs:
           echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
           echo "##[set-output name=artifactVersion;]${version}"
       - name: Archive ${{ env.repoName }} template
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4.6.2
         if: success()
         with:
           name: ${{steps.artifact_file.outputs.artifactName}}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -75,7 +75,7 @@ jobs:
           echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
           echo "##[set-output name=artifactVersion;]${version}"
       - name: Archive ${{ env.repoName }} template
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: success()
         with:
           name: ${{steps.artifact_file.outputs.artifactName}}

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <azure.apiVersion.deployments>2023-07-01</azure.apiVersion.deployments>
         <azure.apiVersion.virtualNetworks>2023-06-01</azure.apiVersion.virtualNetworks>
         <azure.apiVersion.vNetRoleAssignment>2018-09-01-preview</azure.apiVersion.vNetRoleAssignment>
-        <azure.apiVersion.aroCluster>2023-09-04</azure.apiVersion.aroCluster>
+        <azure.apiVersion.aroCluster>2023-04-01</azure.apiVersion.aroCluster>
         <azure.apiVersion.roleAssignment>2022-04-01</azure.apiVersion.roleAssignment>
         <azure.apiVersion.userAssignedIdentities>2023-01-31</azure.apiVersion.userAssignedIdentities>
         <azure.apiVersion.deploymentScript>2023-08-01</azure.apiVersion.deploymentScript>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <azure.apiVersion.deployments>2023-07-01</azure.apiVersion.deployments>
         <azure.apiVersion.virtualNetworks>2023-06-01</azure.apiVersion.virtualNetworks>
         <azure.apiVersion.vNetRoleAssignment>2018-09-01-preview</azure.apiVersion.vNetRoleAssignment>
-        <azure.apiVersion.aroCluster>2023-04-01</azure.apiVersion.aroCluster>
+        <azure.apiVersion.aroCluster>2023-09-04</azure.apiVersion.aroCluster>
         <azure.apiVersion.roleAssignment>2022-04-01</azure.apiVersion.roleAssignment>
         <azure.apiVersion.userAssignedIdentities>2023-01-31</azure.apiVersion.userAssignedIdentities>
         <azure.apiVersion.deploymentScript>2023-08-01</azure.apiVersion.deploymentScript>


### PR DESCRIPTION
## Background of this PR
In light of recent incidents involving GitHub Actions ( [https://www.stepsecurity.io/blog/reviewdog-github-actions-are-compromised](https://nam06.safelinks.protection.outlook.com/?url=https:%2f%2fwww.stepsecurity.io%2fblog%2freviewdog-github-actions-are-compromised&data=05%7c02%7cEdward.Burns%40microsoft.com%7c2e164dbc41814a70b33808dd827ed367%7c72f988bf86f141af91ab2d7cd011db47%7c1%7c0%7c638810203429735777%7cUnknown%7cTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7c0%7c%7c%7c&sdata=vi16rlxw83McXqhRG1wMrm4LQ4i26aSyHYWywOPY9K8%3D&reserved=0), [https://www.theregister.com/2025/03/17/supply_chain_attack_github/](https://nam06.safelinks.protection.outlook.com/?url=https:%2f%2fwww.theregister.com%2f2025%2f03%2f17%2fsupply_chain_attack_github%2f&data=05%7c02%7cEdward.Burns%40microsoft.com%7c2e164dbc41814a70b33808dd827ed367%7c72f988bf86f141af91ab2d7cd011db47%7c1%7c0%7c638810203429763472%7cUnknown%7cTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7c0%7c%7c%7c&sdata=Ozt24lxnD6oIkBlXBCHTBL%2B%2BfD5Wx7XuQhxcZRsc1rE%3D&reserved=0)) the OGHO Team with the recommendation from [oracle/macaron](https://nam06.safelinks.protection.outlook.com/?url=https:%2f%2fgithub.com%2foracle%2fmacaron&data=05%7c02%7cEdward.Burns%40microsoft.com%7c2e164dbc41814a70b33808dd827ed367%7c72f988bf86f141af91ab2d7cd011db47%7c1%7c0%7c638810203429778263%7cUnknown%7cTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7c0%7c%7c%7c&sdata=4IL0aROnYZA3KIBuVOa0yYKPKYe3KVPi3Y6Cigtbquo%3D&reserved=0) team  would like to ask you to pin the actions/download-artifact @v4 action with immutable commit.

For example:   uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1

The reason is that versions of actions/download-artifact before 4.1.3 have a known [vulnerability](https://nam06.safelinks.protection.outlook.com/?url=https:%2f%2fosv.dev%2fvulnerability%2fGHSA-cxww-7g56-2vh6&data=05%7c02%7cEdward.Burns%40microsoft.com%7c2e164dbc41814a70b33808dd827ed367%7c72f988bf86f141af91ab2d7cd011db47%7c1%7c0%7c638810203429805031%7cUnknown%7cTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7c0%7c%7c%7c&sdata=TUayPI5qwekL9ZHI1LCcug%2BEZRCDLlShRCJY%2BFFHkG4%3D&reserved=0). While the repos use v4 which is supposed to pull the latest version of the GitHub Action, the issue is that the users have no control on the specific version of actions/download-artifact . To make sure the repos we identified definitely use a fixed version, they can pin the Action to the immutable commit SHA, e.g., uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1

In general, it is advised that all the GitHub Actions are pinned to the commit SHA and avoid using tags because if the Action is compromised, we guarantee that we don't run the malicious code."


"You can read more about this [here](https://nam06.safelinks.protection.outlook.com/?url=https:%2f%2fdocs.github.com%2fen%2factions%2fsecurity-for-github-actions%2fsecurity-guides%2fsecurity-hardening-for-github-actions%23using-third-party-actions&data=05%7c02%7cEdward.Burns%40microsoft.com%7c2e164dbc41814a70b33808dd827ed367%7c72f988bf86f141af91ab2d7cd011db47%7c1%7c0%7c638810203429817832%7cUnknown%7cTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7c0%7c%7c%7c&sdata=HVIcTCRWxA6qymfZ63ZSPuKkO1p%2f0DDVo7n%2f%2BZ%2BL3Go%3D&reserved=0)"

### More about this PR
- actions/upload-artifact@v4 and actions/download-artifact@v4 typically work together.
- Since we have decided to use the commit hash approach instead of tags to modify actions/download-artifact@v4, it would be best to ensure both workflows are updated with the same pattern.


## Test
https://github.com/azure-javaee/azure.liberty.aro/actions/runs/14636926162
<img width="950" alt="image" src="https://github.com/user-attachments/assets/c1e6b820-9b53-461a-974b-8e8a9c202b72" />
