### PR TITLE
edburns/do-not-use-aro-name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,13 +36,13 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
+        <azure.apiVersion.aroCluster>2024-08-12-preview</azure.apiVersion.aroCluster>
+        <azure.apiVersion.deploymentScript>2023-08-01</azure.apiVersion.deploymentScri
         <azure.apiVersion.deployments>2023-07-01</azure.apiVersion.deployments>
-        <azure.apiVersion.virtualNetworks>2023-06-01</azure.apiVersion.virtualNetworks>
-        <azure.apiVersion.vNetRoleAssignment>2018-09-01-preview</azure.apiVersion.vNetRoleAssignment>
-        <azure.apiVersion.aroCluster>2023-04-01</azure.apiVersion.aroCluster>
         <azure.apiVersion.roleAssignment>2022-04-01</azure.apiVersion.roleAssignment>
         <azure.apiVersion.userAssignedIdentities>2023-01-31</azure.apiVersion.userAssignedIdentities>
-        <azure.apiVersion.deploymentScript>2023-08-01</azure.apiVersion.deploymentScript>
+        <azure.apiVersion.vNetRoleAssignment>2018-09-01-preview</azure.apiVersion.vNetRoleAssignment>
+        <azure.apiVersion.virtualNetworks>2023-06-01</azure.apiVersion.virtualNetworks>pt>
         <!--Testing PID <customer.usage.attribution.id>pid-1a2a9b5a-6c82-42de-a938-9fdb6ffe8e55-partnercenter</customer.usage.attribution.id> -->
         <customer.usage.attribution.id>pid-8942a2f7-32d6-4b69-b504-4c2fb23fe059-partnercenter</customer.usage.attribution.id>
         <aro.start>acdd32ed-5fab-54b6-8d5a-097ed3dcfcf2</aro.start>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <azure.apiVersion.roleAssignment>2022-04-01</azure.apiVersion.roleAssignment>
         <azure.apiVersion.userAssignedIdentities>2023-01-31</azure.apiVersion.userAssignedIdentities>
         <azure.apiVersion.vNetRoleAssignment>2024-07-01</azure.apiVersion.vNetRoleAssignment>
-        <azure.apiVersion.virtualNetworks>2024-07-01</azure.apiVersion.virtualNetworks>pt>
+        <azure.apiVersion.virtualNetworks>2024-07-01</azure.apiVersion.virtualNetworks>
         <!--Testing PID <customer.usage.attribution.id>pid-1a2a9b5a-6c82-42de-a938-9fdb6ffe8e55-partnercenter</customer.usage.attribution.id> -->
         <customer.usage.attribution.id>pid-8942a2f7-32d6-4b69-b504-4c2fb23fe059-partnercenter</customer.usage.attribution.id>
         <aro.start>acdd32ed-5fab-54b6-8d5a-097ed3dcfcf2</aro.start>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
         <azure.apiVersion.aroCluster>2024-08-12-preview</azure.apiVersion.aroCluster>
-        <azure.apiVersion.deploymentScript>2023-08-01</azure.apiVersion.deploymentScri
+        <azure.apiVersion.deploymentScript>2023-08-01</azure.apiVersion.deploymentScript>
         <azure.apiVersion.deployments>2023-07-01</azure.apiVersion.deployments>
         <azure.apiVersion.roleAssignment>2022-04-01</azure.apiVersion.roleAssignment>
         <azure.apiVersion.userAssignedIdentities>2023-01-31</azure.apiVersion.userAssignedIdentities>

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
         <azure.apiVersion.deployments>2023-07-01</azure.apiVersion.deployments>
         <azure.apiVersion.roleAssignment>2022-04-01</azure.apiVersion.roleAssignment>
         <azure.apiVersion.userAssignedIdentities>2023-01-31</azure.apiVersion.userAssignedIdentities>
-        <azure.apiVersion.vNetRoleAssignment>2018-09-01-preview</azure.apiVersion.vNetRoleAssignment>
-        <azure.apiVersion.virtualNetworks>2023-06-01</azure.apiVersion.virtualNetworks>pt>
+        <azure.apiVersion.vNetRoleAssignment>2024-07-01</azure.apiVersion.vNetRoleAssignment>
+        <azure.apiVersion.virtualNetworks>2024-07-01</azure.apiVersion.virtualNetworks>pt>
         <!--Testing PID <customer.usage.attribution.id>pid-1a2a9b5a-6c82-42de-a938-9fdb6ffe8e55-partnercenter</customer.usage.attribution.id> -->
         <customer.usage.attribution.id>pid-8942a2f7-32d6-4b69-b504-4c2fb23fe059-partnercenter</customer.usage.attribution.id>
         <aro.start>acdd32ed-5fab-54b6-8d5a-097ed3dcfcf2</aro.start>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
 
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -96,7 +96,7 @@
                     "preValidation": "Provide required info for cluster configuration",
                     "postValidation": "Done"
                 },
-                "bladeTitle": "ARO",
+                "bladeTitle": "OpenShift",
                 "elements": [
                     {
                         "name": "createCluster",


### PR DESCRIPTION
modified:   src/main/arm/createUiDefinition.json

I see we are still using "ARO" in the offer: https://aka.ms/liberty-aro. We should change this to either OpenShift or Azure Red Hat OpenShift depending on the context.