### PR TITLE
Update version of OLO to 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aro</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
 
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <azure.apiVersion.deployments>2023-07-01</azure.apiVersion.deployments>
         <azure.apiVersion.roleAssignment>2022-04-01</azure.apiVersion.roleAssignment>
         <azure.apiVersion.userAssignedIdentities>2023-01-31</azure.apiVersion.userAssignedIdentities>
-        <azure.apiVersion.vNetRoleAssignment>2024-07-01</azure.apiVersion.vNetRoleAssignment>
+        <azure.apiVersion.vNetRoleAssignment>2022-04-01</azure.apiVersion.vNetRoleAssignment>
         <azure.apiVersion.virtualNetworks>2024-07-01</azure.apiVersion.virtualNetworks>
         <!--Testing PID <customer.usage.attribution.id>pid-1a2a9b5a-6c82-42de-a938-9fdb6ffe8e55-partnercenter</customer.usage.attribution.id> -->
         <customer.usage.attribution.id>pid-8942a2f7-32d6-4b69-b504-4c2fb23fe059-partnercenter</customer.usage.attribution.id>

--- a/src/main/scripts/open-liberty-operator-subscription.yaml
+++ b/src/main/scripts/open-liberty-operator-subscription.yaml
@@ -24,4 +24,4 @@ spec:
   name: open-liberty-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: open-liberty-operator.v1.4.1
+  startingCSV: open-liberty-operator.v1.4.2


### PR DESCRIPTION
The PR is to fix deployment failure (The Open/WebSphere Liberty Operator is not available) by upgrading version of OLO to `1.4.2`.
It also rolls back the version of `vNetRoleAssignment` to `2022-04-01` to fix the regression issue introduced in #134 (details pls see this [comment](https://github.com/WASdev/azure.liberty.aro/pull/134/files#r2061958597)).

## Testing

OLO: [integration-test #103](https://github.com/majguo/azure.liberty.aro/actions/runs/14685783109)
WLO: [integration-test #104](https://github.com/majguo/azure.liberty.aro/actions/runs/14687688899)